### PR TITLE
Fix sidebar mobile: impossibile chiudere e copre tutto lo schermo

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -3,25 +3,34 @@
   id="mySidebar"
   role="navigation"
   aria-label="Navigazione principale"
-  style="z-index:3;"
+  style="z-index:3; flex-direction:column;"
 >
-  <!-- Chiudi (solo mobile) -->
-  <button
-    onclick="w3_close()"
-    class="w3-hide-large"
-    aria-label="Chiudi menu"
-    style="
-      width:100%; background:rgba(255,255,255,0.05); border:none;
-      color:rgba(255,255,255,0.7); font-family:var(--font-sans,'Dosis',sans-serif);
-      font-size:0.85rem; font-weight:600; letter-spacing:0.08em;
-      padding:14px 20px; text-align:left; cursor:pointer;
-      border-bottom:1px solid rgba(255,255,255,0.07);
-      display:flex; align-items:center; gap:10px;
-      min-height:44px;
-    "
-  >
-    <i class="fa fa-times" aria-hidden="true"></i> CHIUDI MENU
-  </button>
+  <!-- Barra superiore mobile: titolo + pulsante chiudi -->
+  <div class="w3-hide-large" style="
+    display:flex; align-items:center; justify-content:space-between;
+    padding:0 16px;
+    height:56px;
+    background:rgba(255,255,255,0.04);
+    border-bottom:1px solid rgba(255,255,255,0.1);
+    flex-shrink:0;
+  ">
+    <span style="font-family:var(--font-sans,'Dosis',sans-serif);font-size:1rem;font-weight:700;color:#fff;letter-spacing:0.06em;">
+      SftP <span style="color:var(--red,#D42B1E);">ITALY</span>
+    </span>
+    <button
+      onclick="w3_close()"
+      aria-label="Chiudi menu"
+      style="
+        background:var(--red,#D42B1E); border:none; color:#fff;
+        width:40px; height:40px; border-radius:50%;
+        font-size:1.2rem; cursor:pointer; display:flex;
+        align-items:center; justify-content:center;
+        flex-shrink:0;
+      "
+    >
+      <i class="fa fa-times" aria-hidden="true"></i>
+    </button>
+  </div>
 
   <!-- Logo / Brand -->
   <div style="padding:36px 24px 24px;">
@@ -80,13 +89,18 @@
   </div>
 </nav>
 
-<!-- Overlay mobile -->
+<!-- Overlay mobile: tap per chiudere -->
 <div
-  class="w3-overlay w3-hide-large"
-  onclick="w3_close()"
-  style="cursor:pointer;"
-  title="Chiudi menu"
   id="myOverlay"
+  onclick="w3_close()"
+  style="
+    display:none; position:fixed; top:0; left:0;
+    width:100%; height:100%;
+    background:rgba(0,0,0,0.55);
+    z-index:2; cursor:pointer;
+  "
+  title="Chiudi menu"
+  aria-hidden="true"
 ></div>
 
 <style>
@@ -112,7 +126,8 @@
 function w3_open() {
   var sidebar = document.getElementById('mySidebar');
   var overlay = document.getElementById('myOverlay');
-  if (sidebar) sidebar.style.display = 'block';
+  // Usare 'flex' perché il sidebar ha flex-direction:column
+  if (sidebar) sidebar.style.display = 'flex';
   if (overlay) overlay.style.display = 'block';
   var btn = document.getElementById('hamburger-btn');
   if (btn) btn.setAttribute('aria-expanded', 'true');

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,9 +1,18 @@
 <nav
-  class="w3-sidebar w3-collapse w3-top"
   id="mySidebar"
   role="navigation"
   aria-label="Navigazione principale"
-  style="z-index:3; flex-direction:column;"
+  style="
+    position:fixed; top:0; left:0; height:100%; z-index:10;
+    display:flex; flex-direction:column; overflow-y:auto;
+    width:min(300px, 75vw);
+    background:#1e1e1e;
+    border-right:3px solid #D42B1E;
+    box-shadow:3px 0 20px rgba(0,0,0,0.35);
+    transform:translateX(-100%);
+    transition:transform 0.3s ease;
+    will-change:transform;
+  "
 >
   <!-- Barra superiore mobile: titolo + pulsante chiudi -->
   <div class="w3-hide-large" style="
@@ -126,19 +135,20 @@
 function w3_open() {
   var sidebar = document.getElementById('mySidebar');
   var overlay = document.getElementById('myOverlay');
-  // Usare 'flex' perché il sidebar ha flex-direction:column
-  if (sidebar) sidebar.style.display = 'flex';
+  if (sidebar) sidebar.classList.add('sidebar-open');
   if (overlay) overlay.style.display = 'block';
   var btn = document.getElementById('hamburger-btn');
   if (btn) btn.setAttribute('aria-expanded', 'true');
+  document.body.style.overflow = 'hidden';
 }
 
 function w3_close() {
   var sidebar = document.getElementById('mySidebar');
   var overlay = document.getElementById('myOverlay');
-  if (sidebar) sidebar.style.display = 'none';
+  if (sidebar) sidebar.classList.remove('sidebar-open');
   if (overlay) overlay.style.display = 'none';
   var btn = document.getElementById('hamburger-btn');
   if (btn) btn.setAttribute('aria-expanded', 'false');
+  document.body.style.overflow = '';
 }
 </script>

--- a/style.css
+++ b/style.css
@@ -359,8 +359,13 @@ img {
 
 .site-main {
   min-height: 100vh;
-  margin-left: var(--sidebar-w);
   transition: margin-left .4s;
+}
+
+@media (min-width: 993px) {
+  .site-main {
+    margin-left: var(--sidebar-w);
+  }
 }
 
 /* Wrapper per pagine generiche (non-post) */
@@ -375,23 +380,16 @@ img {
    SIDEBAR
    ====================================================== */
 
-.w3-sidebar {
-  /* NON mettere display qui: W3.CSS gestisce show/hide su mobile
-     tramite display:none/.w3-collapse — !important lo sovrascrive
-     e causa la sidebar sempre aperta e impossibile da chiudere */
-  width: min(var(--sidebar-w), 75vw) !important;
-  max-width: var(--sidebar-w);
-  background: var(--dark) !important;
-  box-shadow: 3px 0 20px rgba(0,0,0,0.25);
-  border-right: 3px solid var(--red);
-  /* flex solo su desktop — il JS usa display:'flex' su mobile */
+/* Sidebar: visibile su desktop (transform:0), nascosta su mobile (transform:-100%) */
+/* Su mobile si apre aggiungendo la classe .sidebar-open via JS */
+#mySidebar.sidebar-open {
+  transform: translateX(0) !important;
 }
 
-/* Desktop: sempre visibile come colonna flex */
+/* Desktop: sidebar sempre visibile */
 @media (min-width: 993px) {
-  .w3-sidebar {
-    display: flex !important;
-    flex-direction: column;
+  #mySidebar {
+    transform: translateX(0) !important;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -376,14 +376,23 @@ img {
    ====================================================== */
 
 .w3-sidebar {
-  /* Su mobile non supera l'82% dello schermo */
-  width: min(var(--sidebar-w), 82vw) !important;
+  /* NON mettere display qui: W3.CSS gestisce show/hide su mobile
+     tramite display:none/.w3-collapse — !important lo sovrascrive
+     e causa la sidebar sempre aperta e impossibile da chiudere */
+  width: min(var(--sidebar-w), 75vw) !important;
   max-width: var(--sidebar-w);
   background: var(--dark) !important;
-  box-shadow: 3px 0 20px rgba(0,0,0,0.18);
+  box-shadow: 3px 0 20px rgba(0,0,0,0.25);
   border-right: 3px solid var(--red);
-  display: flex !important;
-  flex-direction: column;
+  /* flex solo su desktop — il JS usa display:'flex' su mobile */
+}
+
+/* Desktop: sempre visibile come colonna flex */
+@media (min-width: 993px) {
+  .w3-sidebar {
+    display: flex !important;
+    flex-direction: column;
+  }
 }
 
 .sidebar-logo {


### PR DESCRIPTION
## Problema
La sidebar su mobile copriva tutto lo schermo e non si poteva chiudere. Il conflitto era tra `display:flex !important` nel CSS custom e `display:none` di W3.CSS (senza `!important`) applicato dalla classe `.w3-collapse` su mobile — il CSS custom vinceva sempre, tenendo la sidebar aperta e bloccata.

## Soluzione
Rimosso completamente il legame con W3.CSS per il controllo della visibilità della sidebar:

- La nav `#mySidebar` non ha più classi W3.CSS (`w3-sidebar`, `w3-collapse`, `w3-top`)
- La sidebar è sempre `display:flex` ma **nascosta off-screen** via `transform:translateX(-100%)` (inline style)
- Il JS ora usa `classList.add/remove('sidebar-open')` invece di `style.display`
- CSS: `#mySidebar.sidebar-open { transform: translateX(0) }` apre la sidebar con animazione fluida
- Desktop: `@media(min-width:993px)` forza sempre `transform:translateX(0)` — sidebar sempre visibile
- `document.body.style.overflow = 'hidden'` blocca lo scroll del body mentre il menu è aperto
- `.site-main` ha `margin-left` solo su desktop (su mobile la sidebar è off-screen, non occupa spazio)

## File modificati
- `_includes/sidebar.html` — rimosse classi W3.CSS dalla nav, JS aggiornato a classList
- `style.css` — rimosso blocco `.w3-sidebar`, aggiunte regole `#mySidebar` basate su transform

https://claude.ai/code/session_01V4NgnGr6duU2DN4b6R7WTb