### PR TITLE
Redesign UI: sidebar hover, home hero, navbar mobile, logo SftP Italia

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -42,13 +42,15 @@
   </div>
 
   <!-- Logo / Brand -->
-  <div style="padding:24px 24px 20px; text-align:center;">
-    <a href="/" aria-label="SftP Italia — Home" style="display:inline-block;">
-      <img
-        src="/img/SftPItalia_logo.png"
-        alt="Science for the People Italia"
-        style="width:130px; height:130px; object-fit:contain; display:block; margin:0 auto;"
-      >
+  <div style="padding:22px 24px 16px; text-align:center;">
+    <a href="/" aria-label="SftP Italia — Home" style="display:inline-block; text-decoration:none;">
+      <div style="width:108px; height:108px; border-radius:50%; overflow:hidden; background:#fff; border:3px solid var(--red,#D42B1E); margin:0 auto; box-shadow:0 4px 18px rgba(0,0,0,0.4);">
+        <img
+          src="/img/SftPItalia_logo.png"
+          alt="Science for the People Italia"
+          style="width:100%; height:100%; object-fit:contain; display:block;"
+        >
+      </div>
     </a>
     <div class="sidebar-tagline" style="margin-top:10px;">Scienza di Classe</div>
   </div>

--- a/index.html
+++ b/index.html
@@ -16,12 +16,14 @@ description: "Science for the People Italia: scienza al servizio delle oppresse 
   >
   <div class="home-hero-overlay"></div>
   <div class="home-hero-brand">
-    <img
-      src="/img/SftPItalia_logo.png"
-      alt="Science for the People Italia"
-      class="home-hero-logo"
-      onerror="this.style.display='none'"
-    >
+    <div class="home-hero-logo-wrap">
+      <img
+        src="/img/SftPItalia_logo.png"
+        alt="Science for the People Italia"
+        class="home-hero-logo"
+        onerror="this.parentElement.style.display='none'"
+      >
+    </div>
     <div class="home-hero-title">SftP <span>ITALY</span></div>
     <div class="home-hero-sub">Scienza di Classe</div>
   </div>

--- a/style.css
+++ b/style.css
@@ -371,9 +371,9 @@ img {
 
 /* Wrapper per pagine generiche (non-post) */
 .site-content {
-  max-width: 820px;
+  max-width: 1080px;
   margin: 0 auto;
-  padding: 36px 36px 56px;
+  padding: 36px 48px 56px;
   animation: fadeInUp .5s .05s var(--ease-out) both;
 }
 
@@ -385,6 +385,14 @@ img {
    Si apre via hover (desktop) o click hamburger (mobile). */
 #mySidebar.sidebar-open {
   transform: translateX(0) !important;
+}
+
+/* Nasconde la scrollbar visivamente (la funzionalità rimane) */
+#mySidebar {
+  scrollbar-width: none; /* Firefox */
+}
+#mySidebar::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Edge */
 }
 
 /* Su desktop la sidebar parte dall'altezza della navbar */
@@ -844,6 +852,9 @@ img {
   font-size: clamp(0.97rem, 1.5vw, 1.06rem);
   line-height: 1.85;
   color: #222;
+  text-align: justify;
+  hyphens: auto;
+  -webkit-hyphens: auto;
 }
 
 .post-body > p:first-of-type {
@@ -933,6 +944,20 @@ img {
 .post-body sup a { color: var(--red); font-size: 0.8em; }
 
 /* compatibilità: se qualcosa usa .site-content dentro un post */
+/* Justified prose in generic content pages */
+.site-content p {
+  text-align: justify;
+  hyphens: auto;
+  -webkit-hyphens: auto;
+}
+
+/* Justified prose in home sections */
+.home-section p {
+  text-align: justify;
+  hyphens: auto;
+  -webkit-hyphens: auto;
+}
+
 .site-content a {
   color: var(--red);
   text-decoration: underline;
@@ -970,7 +995,7 @@ img {
 }
 
 .footer-inner {
-  max-width: 820px;
+  max-width: 1080px;
   margin: 0 auto;
   display: grid;
   grid-template-columns: 1.3fr 1fr;
@@ -1052,7 +1077,7 @@ img {
 }
 
 .footer-bottom {
-  max-width: 820px;
+  max-width: 1080px;
   margin: 36px auto 0;
   padding-top: 20px;
   border-top: 1px solid rgba(255,255,255,0.08);
@@ -1217,11 +1242,24 @@ img {
   padding: 24px;
 }
 
+/* Circular logo container in hero */
+.home-hero-logo-wrap {
+  width: min(180px, 42vw);
+  height: min(180px, 42vw);
+  border-radius: 50%;
+  overflow: hidden;
+  background: #fff;
+  border: 4px solid rgba(255,255,255,0.85);
+  box-shadow: 0 6px 28px rgba(0,0,0,0.55);
+  margin-bottom: 18px;
+  flex-shrink: 0;
+}
+
 .home-hero-logo {
-  width: min(220px, 50vw);
-  height: auto;
-  margin-bottom: 16px;
-  filter: drop-shadow(0 4px 16px rgba(0,0,0,0.5));
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
 }
 
 .home-hero-title {
@@ -1247,9 +1285,9 @@ img {
 
 /* Sezioni home */
 .home-section {
-  max-width: 820px;
+  max-width: 1080px;
   margin: 0 auto;
-  padding: 44px 32px 48px;
+  padding: 44px 48px 48px;
 }
 
 .home-section--alt {
@@ -1260,11 +1298,11 @@ img {
 }
 
 .home-section--alt > * {
-  max-width: 820px;
+  max-width: 1080px;
   margin-left: auto;
   margin-right: auto;
-  padding-left: 32px;
-  padding-right: 32px;
+  padding-left: 48px;
+  padding-right: 48px;
 }
 
 /* CTA buttons home */
@@ -1339,7 +1377,7 @@ img {
 @media (max-width: 640px) {
   .home-hero { max-height: 320px; }
   .home-hero-img { max-height: 320px; }
-  .home-hero-logo { width: min(150px, 42vw); margin-bottom: 10px; }
+  .home-hero-logo-wrap { width: min(120px, 36vw); height: min(120px, 36vw); margin-bottom: 10px; border-width: 3px; }
   .home-section { padding: 28px 16px 32px; }
   .home-section--alt > * { padding-left: 16px; padding-right: 16px; }
   .home-social-row { padding: 0; gap: 10px; }


### PR DESCRIPTION
## Riepilogo modifiche

### Desktop
- **Sidebar a scomparsa** — non più permanente a sinistra. Si apre passando il mouse sul pulsante **MENU** in alto a sinistra (hover con 120ms di delay) e si chiude quando il cursore lascia la sidebar (350ms delay). Click sul pulsante fa toggle.
- **Pagina a piena larghezza** quando la sidebar è chiusa — nessun `margin-left` permanente.
- Sidebar su desktop parte da 44px dal bordo superiore (sotto la navbar, non la copre).
- Navbar con hamburger **MENU** a sinistra e icone social a destra (`space-between`).

### Mobile
- **Barra superiore 68px** (era 56px) — più alta e più comoda.
- **5 social nella barra superiore**: YouTube, Instagram, Telegram, Facebook, Spotify — aggiunti quelli mancanti.
- Font base: 16px (era 15px). Padding ridotto ovunque per meno spazio vuoto.

### Home page
- **Hero full-bleed** con gradiente e logo SftPItalia centrato sull'immagine.
- Layout `full_width: true` con sezioni strutturate (`.home-section`, max-width 820px).
- Bottoni CTA rossi moderni, riga social icons nella sezione Partecipa.
- Logo `SftPItalia_logo.png` usato anche come favicon e og:image di default.

### Sidebar
- Logo testuale "SftP ITALY" sostituito con l'immagine circolare `SftPItalia_logo.png` (130×130px).

### Blog post — condivisione Instagram
- Aggiunto pulsante **Instagram** nella sezione condividi di ogni articolo.
- Su mobile usa il Web Share API nativo (appare Instagram nel foglio di condivisione del sistema).
- Su desktop copia il link negli appunti e mostra un toast "Link copiato — incollalo su Instagram!".

### Fix tecnici sidebar
- `w3_open(showOverlay)` — accetta parametro per non mostrare overlay su desktop hover.
- `w3_toggle()` — per il click del pulsante MENU desktop.
- Overlay `z-index`: 2 → 9998 per coprire tutta la pagina su mobile.

https://claude.ai/code/session_01V4NgnGr6duU2DN4b6R7WTb