### PR TITLE
Miglioramenti design: logo, navbar, testi

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,4 +1,4 @@
-<!-- Barra navigazione desktop: hamburger a sinistra + social a destra -->
+<!-- Barra navigazione desktop: hamburger sx + brand centro + social dx -->
 <div id="navbar" role="navigation" aria-label="Menu e social">
 
   <!-- Hamburger + etichetta (desktop) -->
@@ -12,6 +12,20 @@
     <i class="fa fa-bars" aria-hidden="true"></i>
     <span>MENU</span>
   </button>
+
+  <!-- Brand centrato -->
+  <div style="flex:1; display:flex; align-items:center; justify-content:center;">
+    <a href="/" style="
+      font-family:var(--font-sans,'Dosis',sans-serif);
+      font-size:0.88rem; font-weight:700; letter-spacing:0.07em;
+      color:rgba(255,255,255,0.9); text-decoration:none;
+      display:flex; align-items:center; gap:8px;
+    ">
+      <img src="/img/logo.jpg" alt=""
+           style="width:26px;height:26px;border-radius:50%;object-fit:contain;background:#fff;border:1.5px solid var(--red,#D42B1E);flex-shrink:0;">
+      SftP <span style="color:var(--red,#D42B1E);">Italia</span>
+    </a>
+  </div>
 
   <!-- Social icons desktop -->
   <div style="display:flex; align-items:center;">
@@ -47,47 +61,45 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 10px;
+    padding: 0 8px 0 4px;
     z-index: 4;
     box-shadow: 0 2px 12px rgba(0,0,0,0.25);
   "
 >
-  <!-- Hamburger -->
-  <button
-    onclick="w3_open()"
-    aria-label="Apri menu"
-    aria-expanded="false"
-    aria-controls="mySidebar"
-    id="hamburger-btn"
-    style="
-      background: none; border: none; color: #fff;
-      font-size: 1.35rem; cursor: pointer;
-      padding: 8px; border-radius: 6px;
-      min-width: 44px; min-height: 44px;
-      display: flex; align-items: center; justify-content: center;
-      flex-shrink: 0;
-    "
-  >
-    <i class="fa fa-bars" aria-hidden="true"></i>
-  </button>
+  <!-- Sinistra: hamburger + nome sito -->
+  <div style="display:flex; align-items:center; gap:2px; flex-shrink:0; min-width:0;">
+    <button
+      onclick="w3_open()"
+      aria-label="Apri menu"
+      aria-expanded="false"
+      aria-controls="mySidebar"
+      id="hamburger-btn"
+      style="
+        background: none; border: none; color: #fff;
+        font-size: 1.35rem; cursor: pointer;
+        padding: 8px; border-radius: 6px;
+        min-width: 44px; min-height: 44px;
+        display: flex; align-items: center; justify-content: center;
+        flex-shrink: 0;
+      "
+    >
+      <i class="fa fa-bars" aria-hidden="true"></i>
+    </button>
+    <a
+      href="/"
+      style="
+        font-family: var(--font-sans, 'Dosis', sans-serif);
+        font-weight: 700; font-size: 0.9rem;
+        color: #fff; letter-spacing: 0.05em;
+        text-decoration: none; white-space: nowrap;
+      "
+      aria-label="SftP Italia — Home"
+    >
+      SftP <span style="color:var(--red,#D42B1E);">Italia</span>
+    </a>
+  </div>
 
-  <!-- Nome sito centrato -->
-  <a
-    href="/"
-    style="
-      font-family: var(--font-sans, 'Dosis', sans-serif);
-      font-weight: 700; font-size: 1.1rem;
-      color: #fff; letter-spacing: 0.06em;
-      text-decoration: none;
-      position: absolute; left: 50%; transform: translateX(-50%);
-      white-space: nowrap;
-    "
-    aria-label="SftP Italia — Home"
-  >
-    SftP <span style="color:var(--red,#D42B1E);">ITALY</span>
-  </a>
-
-  <!-- Social rapidi: YouTube + Instagram + Telegram + Facebook + Spotify -->
+  <!-- Destra: social rapidi -->
   <div style="display:flex; align-items:center; gap:0; flex-shrink:0;">
     <a href="https://www.youtube.com/@SFTPItalia" target="_blank" rel="noopener" aria-label="YouTube"
        style="color:rgba(255,255,255,0.75); padding:7px 5px; font-size:1rem; min-width:36px; min-height:44px; display:flex; align-items:center; justify-content:center;">

--- a/index.html
+++ b/index.html
@@ -17,12 +17,14 @@ description: "Science for the People Italia: scienza al servizio delle oppresse 
   <div class="home-hero-overlay"></div>
   <div class="home-hero-brand">
     <div class="home-hero-logo-wrap">
-      <img
-        src="/img/SftPItalia_logo.png"
-        alt="Science for the People Italia"
-        class="home-hero-logo"
-        onerror="this.parentElement.style.display='none'"
-      >
+      <picture>
+        <source media="(min-width: 993px)" srcset="/img/logo.jpg">
+        <img
+          src="/img/SftPItalia_logo.png"
+          alt="Science for the People Italia"
+          class="home-hero-logo"
+        >
+      </picture>
     </div>
     <div class="home-hero-title">Science for the People <span>Italia</span></div>
     <div class="home-hero-sub">Scienza di Classe</div>


### PR DESCRIPTION
## Modifiche

- **Logo circolare** in hero e sidebar (sfondo bianco, bordo rosso)
- **Hero home**: `logo.jpg` su desktop, vecchio logo su mobile (`<picture>`)
- **Logo ingrandito** (260px desktop, 160px mobile) con hero più alto (680px)
- **Navbar desktop**: brand "SftP Italia" con mini-logo circolare al centro
- **Header mobile**: testo "SftP Italia" spostato a sinistra accanto all'hamburger (non più sovrapposto alle icone social)
- **Titolo**: "SftP ITALY" → "Science for the People Italia" nell'hero
- **Sidebar desktop**: scrollbar nascosta
- **Testi**: max-width 1080px, giustificati con sillabazione automatica
- **Condivisione Instagram** negli articoli del blog
- **Spazio bianco ridotto** nelle sezioni home

https://claude.ai/code/session_01V4NgnGr6duU2DN4b6R7WTb