### PR TITLE
Navbar brand semplice centrato + colori logo (#D40035, #000, #FA4224)

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -15,22 +15,16 @@
     </button>
   </div>
 
-  <!-- Centro: brand completo -->
+  <!-- Centro: brand -->
   <a href="/" style="
     font-family:var(--font-sans,'Dosis',sans-serif);
+    font-size:0.9rem; font-weight:700; letter-spacing:0.06em;
     color:#fff; text-decoration:none;
-    display:flex; align-items:center; gap:10px;
+    display:flex; align-items:center; gap:9px;
   ">
-    <img src="/img/logo.jpg" alt="Science for the People Italia"
-         style="width:32px;height:32px;border-radius:50%;object-fit:contain;background:#fff;border:2px solid var(--red,#D42B1E);flex-shrink:0;">
-    <div style="display:flex;flex-direction:column;line-height:1.15;">
-      <span style="font-size:0.82rem;font-weight:700;letter-spacing:0.05em;white-space:nowrap;">
-        Science for the People <span style="color:var(--red,#D42B1E);">Italia</span>
-      </span>
-      <span style="font-size:0.58rem;letter-spacing:0.14em;text-transform:uppercase;color:rgba(255,255,255,0.45);font-style:italic;">
-        Scienza di Classe
-      </span>
-    </div>
+    <img src="/img/logo.jpg" alt="SftP Italia"
+         style="width:28px;height:28px;border-radius:50%;object-fit:contain;background:#fff;border:2px solid var(--red,#D40035);flex-shrink:0;">
+    SftP <span style="color:var(--red,#D40035);">Italia</span>
   </a>
 
   <!-- Destra: social icons -->
@@ -63,7 +57,7 @@
   style="
     height: 68px;
     background: var(--dark, #1e1e1e);
-    border-bottom: 3px solid var(--red, #D42B1E);
+    border-bottom: 3px solid var(--red, #D40035);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -101,7 +95,7 @@
       "
       aria-label="SftP Italia — Home"
     >
-      SftP <span style="color:var(--red,#D42B1E);">Italia</span>
+      SftP <span style="color:var(--red,#D40035);">Italia</span>
     </a>
   </div>
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -6,8 +6,8 @@
     position:fixed; top:0; left:0; height:100%; z-index:9999;
     display:flex; flex-direction:column; overflow-y:auto;
     width:min(300px, 75vw);
-    background:#1e1e1e;
-    border-right:3px solid #D42B1E;
+    background:#111111;
+    border-right:3px solid #D40035;
     box-shadow:3px 0 20px rgba(0,0,0,0.35);
     transform:translateX(-100%);
     transition:transform 0.3s ease;
@@ -24,13 +24,13 @@
     flex-shrink:0;
   ">
     <span style="font-family:var(--font-sans,'Dosis',sans-serif);font-size:0.72rem;font-weight:700;color:#fff;letter-spacing:0.04em;line-height:1.2;">
-      Science for the People <span style="color:var(--red,#D42B1E);">Italia</span>
+      Science for the People <span style="color:var(--red,#D40035);">Italia</span>
     </span>
     <button
       onclick="w3_close()"
       aria-label="Chiudi menu"
       style="
-        background:var(--red,#D42B1E); border:none; color:#fff;
+        background:var(--red,#D40035); border:none; color:#fff;
         width:40px; height:40px; border-radius:50%;
         font-size:1.2rem; cursor:pointer; display:flex;
         align-items:center; justify-content:center;
@@ -44,7 +44,7 @@
   <!-- Logo / Brand -->
   <div style="padding:22px 24px 16px; text-align:center;">
     <a href="/" aria-label="SftP Italia — Home" style="display:inline-block; text-decoration:none;">
-      <div style="width:108px; height:108px; border-radius:50%; overflow:hidden; background:#fff; border:3px solid var(--red,#D42B1E); margin:0 auto; box-shadow:0 4px 18px rgba(0,0,0,0.4);">
+      <div style="width:108px; height:108px; border-radius:50%; overflow:hidden; background:#fff; border:3px solid var(--red,#D40035); margin:0 auto; box-shadow:0 4px 18px rgba(0,0,0,0.4);">
         <img
           src="/img/SftPItalia_logo.png"
           alt="Science for the People Italia"
@@ -126,8 +126,8 @@
 }
 .sidebar-social-link:hover {
   color: #fff;
-  background: var(--red, #D42B1E);
-  border-color: var(--red, #D42B1E);
+  background: var(--red-accent, #FA4224);
+  border-color: var(--red-accent, #FA4224);
   transform: translateY(-2px);
 }
 </style>

--- a/style.css
+++ b/style.css
@@ -287,15 +287,16 @@ hr{border:0;border-top:1px solid #eee;margin:20px 0}
 
 /* --- Variabili --- */
 :root {
-  --red:        #D42B1E;
-  --red-dark:   #a81e14;
-  --red-light:  #fde8e6;
-  --black:      #111111;
-  --dark:       #1e1e1e;
+  --red:        #D40035;
+  --red-dark:   #a8002a;
+  --red-accent: #FA4224;
+  --red-light:  #fde6ec;
+  --black:      #000000;
+  --dark:       #111111;
   --grey:       #5a5a5a;
   --grey-light: #e8e8e8;
   --bg:         #ffffff;
-  --bg-alt:     #f7f7f5;
+  --bg-alt:     #f7f5f5;
   --sidebar-w:  300px;
   --font-sans:  'Dosis', 'Segoe UI', Arial, sans-serif;
   --font-serif: 'Lora', Georgia, 'Times New Roman', serif;
@@ -334,17 +335,17 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1.25;
   margin-top: 1.5em;
   margin-bottom: 0.5em;
-  color: #1a1a1a;
+  color: var(--black);
 }
 
 a {
-  color: #EF4430;
+  color: var(--red);
   text-decoration: none;
   transition: color 0.2s ease;
 }
 
 a:hover {
-  color: #c73220;
+  color: var(--red-dark);
 }
 
 img {
@@ -1368,9 +1369,9 @@ img {
 }
 
 .home-social-icon:hover {
-  background: var(--red);
+  background: var(--red-accent);
   color: #fff;
-  border-color: var(--red);
+  border-color: var(--red-accent);
   transform: translateY(-2px);
 }
 


### PR DESCRIPTION
- Navbar: "SftP Italia" + logo circolare, una riga, centrato
- Colori aggiornati ai valori del logo: --red #D40035, --red-dark #a8002a, --red-accent #FA4224 --black #000000, --dark #111111
- Hover icone social: --red-accent (#FA4224) per distinguerlo dal brand
- Rimossi tutti i valori hardcoded vecchi (#D42B1E, #EF4430, ecc.)

https://claude.ai/code/session_01V4NgnGr6duU2DN4b6R7WTb