### PR TITLE
Redesign v4: topbar magazine + nuovi layout articolo/manifesto

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,161 +1,239 @@
-<!-- Top bar magazine. ID = "site-topbar" per non collidere con il CSS legacy
-     che ha regole su #navbar a { float: right; ... } che fanno sparire i link. -->
+<!-- ============================================================
+     TOP BAR magazine — copia esatta del mockup Direction B.
+     ID e classi prefissati `sftp-` per non collidere con NIENTE.
+     ============================================================ -->
 
-<header id="site-topbar" role="banner" aria-label="Intestazione sito">
-
-  <!-- Riga 1: logo + titolo a sx, social + hamburger a dx -->
-  <div class="topbar-top">
-    <a href="/" class="topbar-brand" aria-label="Science for the People Italia — Home">
-      <span class="topbar-logo">
-        <img src="/img/SftPItalia_logo.png" alt="">
-      </span>
-      <span class="topbar-title">
-        <span class="topbar-title-line">Science for the People <span class="topbar-italia">Italia</span></span>
-        <span class="topbar-sub">Scienza di Classe</span>
-      </span>
-    </a>
-
-    <div class="topbar-right">
-      <div class="topbar-social" aria-label="Canali social">
-        <a href="https://www.youtube.com/@SFTPItalia" target="_blank" rel="noopener" aria-label="YouTube" title="YouTube"><i class="fa fa-youtube" aria-hidden="true"></i></a>
-        <a href="https://www.twitch.tv/scienzadiclasse" target="_blank" rel="noopener" aria-label="Twitch" title="Twitch"><i class="fa fa-twitch" aria-hidden="true"></i></a>
-        <a href="https://www.instagram.com/scienzadiclasse/" target="_blank" rel="noopener" aria-label="Instagram" title="Instagram"><i class="fa fa-instagram" aria-hidden="true"></i></a>
-        <a href="https://www.facebook.com/profile.php?id=100094782115818" target="_blank" rel="noopener" aria-label="Facebook" title="Facebook"><i class="fa fa-facebook" aria-hidden="true"></i></a>
-        <a href="https://open.spotify.com/show/7JSij05RVCmrLL5xc0Vey7" target="_blank" rel="noopener" aria-label="Spotify" title="Spotify"><i class="fa fa-spotify" aria-hidden="true"></i></a>
-        <a href="https://t.me/scienzadiclasse" target="_blank" rel="noopener" aria-label="Telegram" title="Telegram"><i class="fa fa-telegram" aria-hidden="true"></i></a>
-      </div>
-
-      <button
-        id="hamburger-btn"
-        class="topbar-hamburger"
-        aria-label="Apri menu"
-        aria-expanded="false"
-        aria-controls="mySidebar"
-        onclick="w3_toggle()"
-      >
-        <i class="fa fa-bars" aria-hidden="true"></i>
-      </button>
-    </div>
+<!-- Striscia nera sottile con email + social -->
+<div class="sftp-strip">
+  <a href="mailto:scienzadiclasse@gmail.com" class="sftp-strip-email">scienzadiclasse@gmail.com</a>
+  <div class="sftp-strip-social">
+    <a href="https://www.youtube.com/@SFTPItalia" target="_blank" rel="noopener" aria-label="YouTube"><i class="fa fa-youtube" aria-hidden="true"></i></a>
+    <a href="https://www.twitch.tv/scienzadiclasse" target="_blank" rel="noopener" aria-label="Twitch"><i class="fa fa-twitch" aria-hidden="true"></i></a>
+    <a href="https://www.instagram.com/scienzadiclasse/" target="_blank" rel="noopener" aria-label="Instagram"><i class="fa fa-instagram" aria-hidden="true"></i></a>
+    <a href="https://www.facebook.com/profile.php?id=100094782115818" target="_blank" rel="noopener" aria-label="Facebook"><i class="fa fa-facebook" aria-hidden="true"></i></a>
+    <a href="https://open.spotify.com/show/7JSij05RVCmrLL5xc0Vey7" target="_blank" rel="noopener" aria-label="Spotify"><i class="fa fa-spotify" aria-hidden="true"></i></a>
+    <a href="https://t.me/scienzadiclasse" target="_blank" rel="noopener" aria-label="Telegram"><i class="fa fa-telegram" aria-hidden="true"></i></a>
   </div>
+</div>
 
-  <!-- Riga 2: nav orizzontale (desktop) -->
-  <nav class="topbar-nav" aria-label="Navigazione principale">
+<!-- Masthead: logo + titolo a sx, nav orizzontale a dx -->
+<header id="sftp-topbar" role="banner">
+  <a href="/" class="sftp-brand" aria-label="Science for the People Italia — Home">
+    <span class="sftp-brand-logo">
+      <img src="/img/SftPItalia_logo.png" alt="">
+    </span>
+    <span class="sftp-brand-text">
+      <span class="sftp-brand-title">Science for the People <span class="sftp-brand-italia">Italia</span></span>
+      <span class="sftp-brand-sub">Scienza di Classe</span>
+    </span>
+  </a>
+
+  <nav class="sftp-nav" aria-label="Navigazione principale">
     <a href="/">Home</a>
     <a href="/blog">Blog</a>
     <a href="/manifesto">Il nostro Manifesto</a>
-    <a href="https://magazine.scienceforthepeople.org/" target="_blank" rel="noopener">SftP Magazine ↗</a>
+    <a href="https://magazine.scienceforthepeople.org/" target="_blank" rel="noopener">SftP Magazine&nbsp;↗</a>
     <a href="/#partecipa">Partecipa</a>
     <a href="/#scrivici">Scrivici</a>
   </nav>
 
+  <button
+    id="hamburger-btn"
+    class="sftp-hamburger"
+    aria-label="Apri menu"
+    aria-expanded="false"
+    aria-controls="mySidebar"
+    onclick="w3_toggle()"
+  >
+    <i class="fa fa-bars" aria-hidden="true"></i>
+  </button>
 </header>
 
 <style>
   /* ============================================================
-     TOP BAR MAGAZINE — selettori prefissati .topbar- per non
-     collidere con i CSS legacy su #navbar / #navbar a.
+     SFTP TOPBAR — selettori prefissati .sftp- + !important per
+     vincere QUALUNQUE regola legacy in style.css. Niente collisioni.
      ============================================================ */
-  #site-topbar {
-    background: #ffffff;
-    border-bottom: 4px solid var(--red, #D40035);
-    box-shadow: 0 1px 0 rgba(0,0,0,0.04);
-    position: sticky; top: 0; z-index: 50;
-    width: 100%;
-  }
 
-  #site-topbar .topbar-top {
-    max-width: 1340px; margin: 0 auto;
-    padding: 14px 32px;
-    display: flex; align-items: center; justify-content: space-between; gap: 24px;
+  /* Striscia nera sopra */
+  .sftp-strip {
+    background: #111111 !important;
+    color: rgba(255,255,255,0.78) !important;
+    padding: 8px 32px !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    font-family: 'Dosis', sans-serif !important;
+    font-size: 0.75rem !important;
+    font-weight: 600 !important;
+    letter-spacing: 0.06em !important;
+    width: 100% !important;
+    box-sizing: border-box !important;
   }
-
-  /* Brand --- !important per battere #navbar a { float: right; padding: 12px; }
-     che potrebbe colpire questi <a> anche dopo rename — manteniamo robustezza */
-  #site-topbar .topbar-brand {
-    display: flex !important; align-items: center; gap: 14px;
-    text-decoration: none !important; color: var(--black, #000) !important;
-    min-width: 0; float: none !important; padding: 0 !important;
+  .sftp-strip-email {
+    color: rgba(255,255,255,0.78) !important;
+    text-decoration: none !important;
+    float: none !important; padding: 0 !important;
   }
-  #site-topbar .topbar-logo {
-    width: 52px; height: 52px; flex-shrink: 0;
-    border-radius: 50%; overflow: hidden; background: #fff;
-    border: 2.5px solid var(--red, #D40035);
-    display: flex; align-items: center; justify-content: center;
+  .sftp-strip-email:hover { color: #fff !important; }
+  .sftp-strip-social {
+    display: flex !important;
+    align-items: center !important;
+    gap: 12px !important;
   }
-  #site-topbar .topbar-logo img { width: 86%; height: 86%; object-fit: contain; display: block; }
-  #site-topbar .topbar-title { display: flex; flex-direction: column; line-height: 1.05; min-width: 0; }
-  #site-topbar .topbar-title-line {
-    font-family: var(--font-sans, 'Dosis', sans-serif);
-    font-weight: 700; font-size: 1.35rem; letter-spacing: 0.005em; color: var(--black, #000);
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  }
-  #site-topbar .topbar-italia { color: var(--red, #D40035); }
-  #site-topbar .topbar-sub {
-    font-family: var(--font-sans, 'Dosis', sans-serif);
-    font-size: 0.65rem; letter-spacing: 0.22em; text-transform: uppercase;
-    color: var(--grey, #5a5a5a); font-weight: 600; margin-top: 4px;
-  }
-
-  #site-topbar .topbar-right { display: flex; align-items: center; gap: 6px; }
-  #site-topbar .topbar-social { display: flex; align-items: center; gap: 2px; }
-  #site-topbar .topbar-social a {
-    color: var(--grey, #5a5a5a) !important; padding: 8px 10px !important; font-size: 1rem;
-    text-decoration: none !important; border-radius: 4px;
-    transition: color .2s, background .2s;
-    display: inline-flex !important; align-items: center; justify-content: center;
-    line-height: 1; float: none !important;
-  }
-  #site-topbar .topbar-social a:hover {
-    color: var(--red, #D40035) !important; background: var(--bg-alt, #f7f5f5) !important;
-  }
-  #site-topbar .topbar-hamburger {
-    background: none; border: none; cursor: pointer; padding: 8px 10px;
-    color: var(--dark, #111); font-size: 1.2rem;
-    border-radius: 4px; margin-left: 4px;
-    display: none;
-  }
-  #site-topbar .topbar-hamburger:hover { background: var(--bg-alt, #f7f5f5); }
-
-  #site-topbar .topbar-nav {
-    background: var(--dark, #111111);
-    display: flex; align-items: stretch; justify-content: center; gap: 0;
-    width: 100%; overflow: hidden;
-  }
-  #site-topbar .topbar-nav a {
-    color: rgba(255,255,255,0.85) !important; text-decoration: none !important;
-    font-family: var(--font-sans, 'Dosis', sans-serif);
-    font-weight: 700; font-size: 0.78rem;
-    letter-spacing: 0.16em; text-transform: uppercase;
-    padding: 14px 22px !important;
-    transition: color .2s, background .2s;
-    border-bottom: 3px solid transparent;
+  .sftp-strip-social a {
+    color: rgba(255,255,255,0.78) !important;
+    text-decoration: none !important;
+    font-size: 0.85rem !important;
+    line-height: 1 !important;
+    padding: 0 !important;
     float: none !important;
-    display: inline-flex; align-items: center;
+    display: inline-flex !important;
+    align-items: center !important;
+    transition: color .2s !important;
   }
-  #site-topbar .topbar-nav a:hover {
-    color: #fff !important;
-    background: rgba(255,255,255,0.06) !important;
-    border-bottom-color: var(--red, #D40035);
+  .sftp-strip-social a:hover { color: #D40035 !important; background: transparent !important; }
+
+  /* Masthead bianca */
+  #sftp-topbar {
+    background: #ffffff !important;
+    border-bottom: 4px solid #D40035 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    gap: 24px !important;
+    padding: 18px 32px !important;
+    width: 100% !important;
+    box-sizing: border-box !important;
+    position: relative !important;
+    z-index: 50 !important;
+    overflow: visible !important;
   }
 
-  /* --- Mobile: nav orizzontale collassa, hamburger compare --- */
-  @media (max-width: 768px) {
-    #site-topbar .topbar-top { padding: 10px 16px; }
-    #site-topbar .topbar-logo { width: 44px; height: 44px; }
-    #site-topbar .topbar-title-line { font-size: 1.05rem; }
-    #site-topbar .topbar-sub { font-size: 0.58rem; letter-spacing: 0.18em; }
-    #site-topbar .topbar-social a { padding: 6px 6px !important; font-size: 0.95rem; }
-    #site-topbar .topbar-social a:nth-child(n+4) { display: none; }
-    #site-topbar .topbar-hamburger { display: inline-flex; }
-    #site-topbar .topbar-nav { display: none; }
+  /* Brand */
+  #sftp-topbar .sftp-brand {
+    display: flex !important;
+    align-items: center !important;
+    gap: 16px !important;
+    text-decoration: none !important;
+    color: #000 !important;
+    flex-shrink: 0 !important;
+    float: none !important;
+    padding: 0 !important;
   }
-  @media (max-width: 420px) {
-    #site-topbar .topbar-social a:nth-child(n+3) { display: none; }
+  #sftp-topbar .sftp-brand-logo {
+    width: 56px !important;
+    height: 56px !important;
+    flex-shrink: 0 !important;
+    border-radius: 50% !important;
+    overflow: hidden !important;
+    background: #fff !important;
+    border: 2.5px solid #D40035 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+  }
+  #sftp-topbar .sftp-brand-logo img {
+    width: 86% !important;
+    height: 86% !important;
+    object-fit: contain !important;
+    display: block !important;
+  }
+  #sftp-topbar .sftp-brand-text {
+    display: flex !important;
+    flex-direction: column !important;
+    line-height: 1 !important;
+    min-width: 0 !important;
+  }
+  #sftp-topbar .sftp-brand-title {
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700 !important;
+    font-size: 1.55rem !important;
+    color: #000 !important;
+    line-height: 1.05 !important;
+    letter-spacing: 0.005em !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+  }
+  #sftp-topbar .sftp-brand-italia { color: #D40035 !important; }
+  #sftp-topbar .sftp-brand-sub {
+    font-family: 'Dosis', sans-serif !important;
+    font-size: 0.7rem !important;
+    font-weight: 600 !important;
+    color: #5a5a5a !important;
+    letter-spacing: 0.22em !important;
+    text-transform: uppercase !important;
+    margin-top: 6px !important;
   }
 
-  /* --- Compensa il padding-top di .site-main per la nuova top bar --- */
-  @media (min-width: 993px) {
-    .w3-main.site-main, .site-main { padding-top: 0 !important; }
+  /* Nav orizzontale a destra */
+  #sftp-topbar .sftp-nav {
+    display: flex !important;
+    align-items: center !important;
+    gap: 6px !important;
+    flex-wrap: nowrap !important;
+    overflow: hidden !important;
+  }
+  #sftp-topbar .sftp-nav a {
+    color: #000 !important;
+    text-decoration: none !important;
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700 !important;
+    font-size: 0.78rem !important;
+    letter-spacing: 0.12em !important;
+    text-transform: uppercase !important;
+    padding: 8px 14px !important;
+    border-bottom: 2px solid transparent !important;
+    transition: color .2s, border-color .2s, background .2s !important;
+    float: none !important;
+    white-space: nowrap !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    background: transparent !important;
+  }
+  #sftp-topbar .sftp-nav a:hover {
+    color: #D40035 !important;
+    border-bottom-color: #D40035 !important;
+    background: transparent !important;
+  }
+
+  /* Hamburger: nascosto su desktop, mostrato su mobile */
+  #sftp-topbar .sftp-hamburger {
+    display: none !important;
+    background: none !important;
+    border: none !important;
+    cursor: pointer !important;
+    padding: 8px 10px !important;
+    color: #111 !important;
+    font-size: 1.3rem !important;
+  }
+  #sftp-topbar .sftp-hamburger:hover { background: #f7f5f5 !important; }
+
+  /* --- Reset di regole legacy che potrebbero ancora colpire --- */
+  #sftp-topbar a, .sftp-strip a {
+    float: none !important;
+    background-color: transparent !important;
+  }
+
+  /* --- Compensa eventuale padding-top legacy --- */
+  .w3-main.site-main, .site-main {
+    padding-top: 0 !important;
+    margin-top: 0 !important;
+  }
+
+  /* --- Mobile (≤ 900px): nav collassa, mostra hamburger --- */
+  @media (max-width: 900px) {
+    .sftp-strip { padding: 6px 14px !important; font-size: 0.7rem !important; }
+    .sftp-strip-email { display: none !important; }
+    .sftp-strip-social { width: 100% !important; justify-content: center !important; gap: 16px !important; }
+
+    #sftp-topbar { padding: 12px 16px !important; gap: 12px !important; }
+    #sftp-topbar .sftp-brand-logo { width: 44px !important; height: 44px !important; }
+    #sftp-topbar .sftp-brand-title { font-size: 1.1rem !important; }
+    #sftp-topbar .sftp-brand-sub { font-size: 0.6rem !important; letter-spacing: 0.18em !important; margin-top: 3px !important; }
+    #sftp-topbar .sftp-nav { display: none !important; }
+    #sftp-topbar .sftp-hamburger { display: inline-flex !important; }
   }
 </style>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,21 +7,15 @@
   <title>{{ page.title | default: site.title }}</title>
   <meta name="description" content="{{ page.description | default: site.description }}">
 
-  <!-- Preconnect for performance -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-
-  <!-- Fonts: Dosis (titoli/UI) + Lora (corpo) -->
   <link href="https://fonts.googleapis.com/css2?family=Dosis:wght@400;600;700&family=Lora:ital,wght@0,400;0,600;1,400;1,600&display=swap" rel="stylesheet">
 
-  <!-- Styles -->
   <link rel="stylesheet" href="/style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 
-  <!-- Favicon -->
   <link rel="icon" href="/img/SftPItalia_logo.png" type="image/png">
 
-  <!-- Open Graph -->
   <meta property="og:title" content="{{ page.title | default: site.title }}" />
   <meta property="og:description" content="{{ page.description | default: site.description }}" />
   <meta property="og:image" content="{{ page.image | default: '/img/logo.jpg' }}" />
@@ -30,24 +24,19 @@
   <meta property="og:site_name" content="{{ site.title }}" />
   <meta property="og:locale" content="{{ page.locale | default: 'it_IT' }}" />
 
-  <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="{{ page.title | default: site.title }}" />
   <meta name="twitter:description" content="{{ page.description | default: site.description }}" />
   <meta name="twitter:image" content="{{ page.image | default: '/img/logo.jpg' }}" />
 
   {% if page.layout == 'post' %}
-  <!-- Article structured data -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": {{ page.title | jsonify }},
     "datePublished": "{{ page.date | date_to_xmlschema }}",
-    "author": {
-      "@type": "Person",
-      "name": {{ page.author | default: "SFTP Italia" | jsonify }}
-    },
+    "author": { "@type": "Person", "name": {{ page.author | default: "SFTP Italia" | jsonify }} },
     "image": {{ page.image | default: "/img/smol_logo.png" | jsonify }},
     "publisher": {
       "@type": "Organization",
@@ -57,17 +46,31 @@
   }
   </script>
   {% endif %}
+
+  <!-- Override globale: rimuove i conflitti del CSS legacy con il nuovo topbar -->
+  <style>
+    /* Sidebar resta in DOM (serve all'hamburger mobile) ma niente padding-top forzato */
+    body { margin: 0; }
+    .w3-main.site-main, .site-main {
+      padding-top: 0 !important;
+      margin-top: 0 !important;
+      margin-left: 0 !important;
+    }
+    /* Nasconde il vecchio header mobile fisso, sostituito dal nuovo topbar */
+    body > header.w3-top { display: none !important; }
+  </style>
 </head>
 
 <body>
 
-  <!-- Sidebar/menu -->
+  <!-- Sidebar (resta per accessibilità mobile via hamburger del topbar) -->
   {% include sidebar.html %}
+
+  <!-- NUOVO topbar magazine -->
   {% include navbar.html %}
 
-  <!-- Main content -->
-  <div class="w3-main site-main">
-
+  <!-- Main content (full width) -->
+  <main class="site-main" role="main">
     {% if page.layout == 'post' or page.full_width %}
       {{ content }}
     {% else %}
@@ -75,8 +78,7 @@
         {{ content }}
       </div>
     {% endif %}
-
-  </div>
+  </main>
 
   {% include footer.html %}
 
@@ -91,19 +93,7 @@
         if (captionText) captionText.innerHTML = element.alt;
       }
     }
-
-    // Smooth scroll for anchor links
-    document.querySelectorAll('a[href^="#"]').forEach(function(anchor) {
-      anchor.addEventListener('click', function(e) {
-        var target = document.querySelector(this.getAttribute('href'));
-        if (target) {
-          e.preventDefault();
-          target.scrollIntoView({ behavior: 'smooth' });
-        }
-      });
-    });
   </script>
 
 </body>
-
 </html>

--- a/_layouts/manifesto.html
+++ b/_layouts/manifesto.html
@@ -5,137 +5,198 @@ layout: default
 <style>
   /* ============================================================
      MANIFESTO — pagina dedicata (.mn- prefisso)
-     Il corpo del manifesto resta esattamente quello in manifesto.markdown.
-     Questo layout aggiunge solo: hero con logo + titolo, e tipografia ampia.
      ============================================================ */
-  .mn-page { background: var(--bg); color: var(--dark); font-family: var(--font-sans); }
+  .mn-page { background: #fff; color: #111; font-family: 'Dosis', sans-serif; }
 
+  /* HERO */
   .mn-hero {
-    background: var(--dark, #111); color: #fff;
-    padding: 64px 32px 48px;
-    border-bottom: 4px solid var(--red);
-    text-align: center; position: relative; overflow: hidden;
+    background: #111;
+    color: #fff;
+    padding: 80px 32px 60px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
   }
   .mn-hero::before {
     content: 'MANIFESTO';
     position: absolute; inset: 0;
-    font-family: var(--font-sans); font-weight: 700;
-    font-size: clamp(8rem, 22vw, 18rem); letter-spacing: -0.02em;
-    color: rgba(255,255,255,0.04); line-height: 1;
-    display: flex; align-items: center; justify-content: center;
-    pointer-events: none; z-index: 1;
+    font-family: 'Dosis', sans-serif;
+    font-weight: 700;
+    font-size: clamp(8rem, 22vw, 18rem);
+    letter-spacing: -0.02em;
+    color: rgba(255,255,255,0.05);
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    z-index: 1;
   }
-  .mn-hero-inner { position: relative; z-index: 2; max-width: 880px; margin: 0 auto; }
+  .mn-hero-inner {
+    position: relative;
+    z-index: 2;
+    max-width: 920px;
+    margin: 0 auto;
+  }
   .mn-logo {
-    width: 96px; height: 96px; margin: 0 auto 18px;
-    border-radius: 50%; overflow: hidden; background: #fff;
-    border: 3px solid var(--red);
-    display: flex; align-items: center; justify-content: center;
+    width: 96px; height: 96px;
+    margin: 0 auto 22px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: #fff;
+    border: 3px solid #D40035;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     box-shadow: 0 6px 24px rgba(0,0,0,0.4);
   }
-  .mn-logo img { width: 88%; height: 88%; object-fit: contain; display: block; }
+  .mn-logo img {
+    width: 88%; height: 88%;
+    object-fit: contain;
+    display: block;
+  }
   .mn-kicker {
-    font-family: var(--font-sans); font-weight: 700;
-    font-size: 0.72rem; letter-spacing: 0.22em; text-transform: uppercase;
-    color: var(--red); margin-bottom: 14px;
+    font-family: 'Dosis', sans-serif;
+    font-weight: 700;
+    font-size: 0.78rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: #D40035;
+    margin-bottom: 16px;
   }
   .mn-title {
-    margin: 0;
-    font-family: var(--font-sans); font-weight: 700;
-    font-size: clamp(2.4rem, 7vw, 4.8rem); line-height: 0.98;
-    letter-spacing: -0.02em; color: #fff;
+    margin: 0 !important;
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700;
+    font-size: clamp(2.8rem, 8vw, 5.5rem);
+    line-height: 0.98;
+    letter-spacing: -0.02em;
+    color: #fff !important;
   }
-  .mn-title span { color: var(--red); }
-  .mn-meta {
-    margin-top: 22px;
-    font-family: var(--font-sans); font-size: 0.78rem;
-    letter-spacing: 0.04em; color: rgba(255,255,255,0.6);
-    display: flex; justify-content: center; gap: 18px; flex-wrap: wrap;
-  }
-  .mn-meta .fa { color: var(--red); margin-right: 5px; }
+  .mn-title span { color: #D40035; }
 
-  /* Corpo manifesto: tipografia da poster scrollabile */
+  /* Bordo rosso sotto hero */
+  .mn-hero-divider {
+    height: 4px;
+    background: #D40035;
+  }
+
+  /* CORPO */
   .mn-body {
-    max-width: 820px; margin: 0 auto;
-    padding: 56px 32px 64px;
-    font-family: var(--font-serif); font-size: 1.1rem;
-    line-height: 1.85; color: var(--dark);
-    text-align: justify; hyphens: auto; -webkit-hyphens: auto;
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 64px 32px 56px;
+    font-family: 'Lora', serif;
+    font-size: 1.12rem;
+    line-height: 1.85;
+    color: #222;
+    text-align: justify;
+    hyphens: auto; -webkit-hyphens: auto;
   }
-  .mn-body > p:first-of-type::first-letter {
-    font-family: var(--font-sans); font-weight: 700;
-    font-size: 4.8em; line-height: 0.82;
-    float: left; color: var(--red); margin: 10px 14px 0 0;
-  }
-  .mn-body p { margin: 0 0 24px; }
+  .mn-body p { margin: 0 0 1.3em; }
+  .mn-body p:first-of-type { font-size: 1.08em; color: #000; }
   .mn-body h1, .mn-body h2 {
-    font-family: var(--font-sans); font-weight: 700;
-    line-height: 1.15; color: var(--black);
-    margin: 2.2em 0 0.4em;
-    padding-bottom: 0.35em; border-bottom: 3px solid var(--red);
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700;
+    line-height: 1.15;
+    color: #000;
+    margin: 2.4em 0 0.5em !important;
+    padding-bottom: 0.35em;
+    border-bottom: 3px solid #D40035;
     text-align: left;
   }
-  .mn-body h1 { font-size: clamp(1.7rem, 3.5vw, 2.4rem); }
+  .mn-body h1 { font-size: clamp(1.7rem, 3.6vw, 2.4rem); }
   .mn-body h2 { font-size: clamp(1.4rem, 2.8vw, 1.85rem); }
   .mn-body h3 {
-    font-family: var(--font-sans); font-weight: 700;
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700;
     font-size: clamp(1.15rem, 2.4vw, 1.4rem);
-    margin: 1.8em 0 0.4em; color: var(--dark);
+    margin: 1.8em 0 0.4em !important;
+    color: #222;
   }
+  .mn-body strong, .mn-body b { color: #000; }
   .mn-body blockquote {
-    margin: 2em 0; padding: 22px 28px 22px 32px;
-    border-left: 5px solid var(--red);
-    background: var(--red-light); color: var(--dark);
-    font-style: italic; font-size: 1.12em;
+    margin: 2em 0;
+    padding: 22px 28px 22px 32px;
+    border-left: 5px solid #D40035;
+    background: #fde6ec;
+    color: #111;
+    font-style: italic;
+    font-size: 1.1em;
   }
   .mn-body blockquote p { margin: 0; }
-  .mn-body strong, .mn-body b { color: var(--black); }
   .mn-body a {
-    color: var(--red); text-decoration: underline;
+    color: #D40035;
+    text-decoration: underline;
     text-underline-offset: 3px;
   }
-  .mn-body a:hover { color: var(--red-dark); }
+  .mn-body a:hover { color: #a8002a; }
 
   /* CTA finale */
   .mn-cta {
-    background: var(--bg-alt); border-top: 1px solid var(--grey-light);
-    padding: 48px 32px;
+    background: #f7f5f5;
+    border-top: 1px solid #e8e8e8;
+    padding: 56px 32px;
   }
   .mn-cta-inner {
-    max-width: 820px; margin: 0 auto;
-    display: grid; grid-template-columns: 1fr auto; gap: 28px; align-items: center;
+    max-width: 920px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 32px;
+    align-items: center;
   }
   .mn-cta h2 {
-    margin: 0; font-family: var(--font-sans); font-weight: 700;
-    font-size: clamp(1.5rem, 3vw, 2.2rem); color: var(--red);
-    padding-bottom: 6px; border-bottom: 3px solid var(--red);
+    margin: 0 0 8px;
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700;
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+    color: #D40035;
+    padding-bottom: 6px;
+    border-bottom: 3px solid #D40035;
     display: inline-block;
   }
   .mn-cta p {
-    font-family: var(--font-serif); font-size: 1.05rem;
-    line-height: 1.55; color: var(--dark); margin: 14px 0 0;
+    font-family: 'Lora', serif;
+    font-size: 1.05rem;
+    line-height: 1.55;
+    color: #222;
+    margin: 14px 0 0;
   }
-  .mn-cta-buttons { display: flex; gap: 10px; flex-wrap: wrap; }
+  .mn-cta-buttons {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
   .mn-btn {
-    background: var(--red); color: #fff !important;
-    padding: 13px 22px; font-family: var(--font-sans);
-    font-weight: 700; font-size: 0.78rem; letter-spacing: 0.08em;
-    text-transform: uppercase; text-decoration: none !important;
-    display: inline-flex; align-items: center; gap: 8px;
+    background: #D40035;
+    color: #fff !important;
+    padding: 14px 22px;
+    font-family: 'Dosis', sans-serif;
+    font-weight: 700;
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-decoration: none !important;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     transition: background .2s, transform .15s;
   }
-  .mn-btn:hover { background: var(--red-dark); transform: translateY(-1px); }
+  .mn-btn:hover { background: #a8002a; transform: translateY(-1px); }
   .mn-btn--outline {
-    background: transparent; color: var(--red) !important;
-    border: 2px solid var(--red); padding: 11px 20px;
+    background: transparent;
+    color: #D40035 !important;
+    border: 2px solid #D40035;
+    padding: 12px 20px;
   }
-  .mn-btn--outline:hover { background: var(--red); color: #fff !important; }
+  .mn-btn--outline:hover { background: #D40035; color: #fff !important; }
 
   @media (max-width: 768px) {
-    .mn-hero { padding: 44px 20px 36px; }
-    .mn-body { padding: 36px 20px 48px; font-size: 1.02rem; }
-    .mn-body > p:first-of-type::first-letter { font-size: 3.6em; }
-    .mn-cta { padding: 36px 20px; }
+    .mn-hero { padding: 48px 18px 36px; }
+    .mn-logo { width: 76px; height: 76px; margin-bottom: 16px; }
+    .mn-body { padding: 40px 18px 40px; font-size: 1.02rem; }
+    .mn-cta { padding: 36px 18px; }
     .mn-cta-inner { grid-template-columns: 1fr; }
   }
 </style>
@@ -147,17 +208,11 @@ layout: default
       <div class="mn-logo">
         <img src="/img/SftPItalia_logo.png" alt="Science for the People Italia">
       </div>
-      <div class="mn-kicker">↳ Documento fondante</div>
+      <div class="mn-kicker">↳ Documento</div>
       <h1 class="mn-title">Il nostro <span>manifesto.</span></h1>
-      {% assign words = content | number_of_words %}
-      <div class="mn-meta">
-        {% if words > 180 %}
-        <span><i class="fa fa-clock-o" aria-hidden="true"></i>{{ words | divided_by: 200 | plus: 1 }} min di lettura</span>
-        {% endif %}
-        <span><i class="fa fa-file-text-o" aria-hidden="true"></i>{{ words }} parole</span>
-      </div>
     </div>
   </header>
+  <div class="mn-hero-divider"></div>
 
   <div class="mn-body">
     {{ content }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,143 +4,183 @@ layout: default
 
 <style>
   /* ============================================================
-     ARTICOLO — magazine layout (classi .ma- prefissate)
+     ARTICOLO — magazine layout (.ma- prefisso, !important strategici
+     per battere .post-* / .site-content del CSS legacy).
      ============================================================ */
-  .ma-article { background: var(--bg); color: var(--dark); font-family: var(--font-sans); }
+  .ma-article { background: #ffffff; color: #111; font-family: 'Dosis', sans-serif; }
 
-  /* Hero photo full-bleed sopra il titolo */
+  /* Hero photo full-bleed */
   .ma-hero {
-    width: 100%; max-height: 540px; overflow: hidden;
-    background: var(--dark);
+    width: 100%; max-height: 520px; overflow: hidden;
+    background: #111;
   }
   .ma-hero img {
-    width: 100%; height: 100%; max-height: 540px;
+    width: 100%; height: auto; max-height: 520px;
     object-fit: cover; display: block;
   }
 
   /* Header articolo */
   .ma-header {
-    max-width: 880px; margin: 0 auto;
-    padding: 36px 32px 32px;
-    border-bottom: 3px solid var(--red);
+    max-width: 920px; margin: 0 auto;
+    padding: 48px 32px 32px;
+    border-bottom: 3px solid #D40035;
   }
-  .ma-header-tags { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 12px; }
+  .ma-header-tags { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 14px; }
   .ma-tag {
-    font-family: var(--font-sans); font-weight: 700;
-    font-size: 0.7rem; letter-spacing: 0.16em; text-transform: uppercase;
-    color: var(--red); padding: 0;
+    font-family: 'Dosis', sans-serif !important; font-weight: 700;
+    font-size: 0.72rem; letter-spacing: 0.16em; text-transform: uppercase;
+    color: #D40035 !important; padding: 0; background: none !important;
   }
   .ma-tag::before { content: '▶ '; }
   .ma-title {
-    margin: 0;
-    font-family: var(--font-serif); font-weight: 700;
-    font-size: clamp(2rem, 5vw, 3.6rem); line-height: 1.08;
-    letter-spacing: -0.01em; color: var(--black);
+    margin: 0 !important;
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700 !important;
+    font-size: clamp(2.2rem, 5vw, 3.8rem) !important;
+    line-height: 1.05 !important;
+    letter-spacing: -0.01em !important;
+    color: #000 !important;
+    text-align: left !important;
   }
   .ma-subtitle {
-    font-family: var(--font-serif); font-style: italic;
-    font-size: clamp(1.05rem, 2vw, 1.3rem); line-height: 1.45;
-    color: var(--grey); margin: 18px 0 22px;
+    font-family: 'Lora', serif !important;
+    font-style: italic !important;
+    font-size: clamp(1.1rem, 2vw, 1.35rem) !important;
+    line-height: 1.45 !important;
+    color: #5a5a5a !important;
+    margin: 18px 0 22px !important;
   }
   .ma-meta {
-    display: flex; flex-wrap: wrap; gap: 18px;
-    font-family: var(--font-sans); font-size: 0.82rem;
-    letter-spacing: 0.04em; color: var(--grey);
+    display: flex; flex-wrap: wrap; gap: 20px;
+    font-family: 'Dosis', sans-serif; font-size: 0.85rem;
+    letter-spacing: 0.04em; color: #5a5a5a;
   }
-  .ma-meta .fa { color: var(--red); margin-right: 5px; }
-  .ma-meta b { color: var(--dark); font-weight: 700; }
+  .ma-meta .fa { color: #D40035; margin-right: 5px; }
+  .ma-meta b { color: #111; font-weight: 700; }
 
   /* Body */
   .ma-body {
     max-width: 760px; margin: 0 auto;
-    padding: 40px 32px 48px;
-    font-family: var(--font-serif); font-size: 1.08rem;
-    line-height: 1.85; color: var(--dark);
-    text-align: justify; hyphens: auto; -webkit-hyphens: auto;
+    padding: 40px 32px 32px;
+    font-family: 'Lora', serif;
+    font-size: 1.1rem;
+    line-height: 1.85;
+    color: #222;
+    text-align: justify;
+    hyphens: auto; -webkit-hyphens: auto;
   }
-  .ma-body > p:first-of-type::first-letter {
-    font-family: var(--font-sans); font-weight: 700;
-    font-size: 4.4em; line-height: 0.85;
-    float: left; color: var(--red); margin: 8px 12px 0 0;
+  .ma-body p { margin: 0 0 1.2em; }
+  .ma-body p:first-of-type { font-size: 1.06em; color: #000; }
+  .ma-body h1, .ma-body h2 {
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700;
+    line-height: 1.2;
+    margin: 2.2em 0 0.55em !important;
+    color: #000;
+    padding-bottom: 0.3em;
+    border-bottom: 2px solid #D40035;
   }
-  .ma-body h2 {
-    font-family: var(--font-sans); font-weight: 700;
-    font-size: clamp(1.4rem, 2.6vw, 1.7rem); line-height: 1.2;
-    margin: 2.2em 0 0.5em; padding-bottom: 0.35em;
-    border-bottom: 2px solid var(--red); color: var(--black);
-  }
+  .ma-body h1 { font-size: clamp(1.5rem, 3vw, 2rem); }
+  .ma-body h2 { font-size: clamp(1.3rem, 2.4vw, 1.6rem); }
   .ma-body h3 {
-    font-family: var(--font-sans); font-weight: 700;
-    font-size: clamp(1.1rem, 2.2vw, 1.3rem);
-    margin: 1.8em 0 0.4em; color: var(--dark);
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700;
+    font-size: clamp(1.1rem, 2vw, 1.25rem);
+    margin: 1.8em 0 0.4em !important;
+    color: #222;
   }
   .ma-body a {
-    color: var(--red); text-decoration: underline;
-    text-underline-offset: 3px; text-decoration-color: rgba(212,0,53,0.4);
+    color: #D40035;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    text-decoration-color: rgba(212,0,53,0.4);
   }
-  .ma-body a:hover { color: var(--red-dark); text-decoration-color: var(--red-dark); }
+  .ma-body a:hover { color: #a8002a; text-decoration-color: #a8002a; }
   .ma-body blockquote {
-    margin: 2em 0; padding: 18px 26px 18px 30px;
-    border-left: 5px solid var(--red);
-    background: var(--red-light);
-    font-style: italic; color: var(--dark);
-    font-size: 1.08em;
+    margin: 2em 0;
+    padding: 20px 26px 20px 30px;
+    border-left: 5px solid #D40035;
+    background: #fde6ec;
+    font-style: italic;
+    color: #111;
+    font-size: 1.06em;
   }
   .ma-body blockquote p { margin: 0; }
   .ma-body img {
-    border-radius: 4px; margin: 1.5em auto;
-    max-width: 100%; height: auto;
+    border-radius: 4px;
+    margin: 1.5em auto;
+    max-width: 100%;
+    height: auto;
   }
   .ma-body code {
-    background: var(--bg-alt); color: var(--red-dark);
-    padding: 2px 6px; font-size: 0.92em;
-    font-family: 'Consolas','Courier New', monospace;
+    background: #f7f5f5;
+    color: #a8002a;
+    padding: 2px 6px;
+    font-size: 0.92em;
+    font-family: 'Consolas', monospace;
   }
   .ma-body pre {
-    background: var(--dark); color: #d4d4d4;
-    padding: 20px 24px; overflow-x: auto;
-    font-size: 0.86rem; line-height: 1.6; margin: 1.5em 0;
+    background: #111;
+    color: #d4d4d4;
+    padding: 20px 24px;
+    overflow-x: auto;
+    font-size: 0.85rem;
+    line-height: 1.6;
+    margin: 1.5em 0;
   }
   .ma-body pre code { background: none; color: inherit; padding: 0; }
-  .ma-body .footnotes {
-    margin-top: 3em; padding-top: 1.5em;
-    border-top: 1px solid var(--grey-light);
-    font-size: 0.85rem; color: var(--grey);
-    font-family: var(--font-sans); line-height: 1.6;
-  }
-  .ma-body sup, .ma-body sup a { color: var(--red); font-size: 0.85em; }
+  .ma-body strong, .ma-body b { color: #000; }
 
   /* Footer articolo */
   .ma-footer {
-    max-width: 880px; margin: 0 auto;
-    padding: 28px 32px 40px;
-    border-top: 2px solid var(--grey-light);
-    display: flex; align-items: center; justify-content: space-between;
-    flex-wrap: wrap; gap: 16px;
-    font-family: var(--font-sans);
+    max-width: 920px; margin: 0 auto;
+    padding: 24px 32px 48px;
+    border-top: 2px solid #e8e8e8;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 16px;
+    font-family: 'Dosis', sans-serif;
   }
   .ma-back {
-    font-size: 0.78rem; font-weight: 700;
-    letter-spacing: 0.1em; text-transform: uppercase;
-    color: var(--red); text-decoration: none;
-    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #D40035;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
   }
-  .ma-back:hover { color: var(--red-dark); }
-  .ma-share { display: flex; align-items: center; gap: 14px; }
+  .ma-back:hover { color: #a8002a; }
+  .ma-share {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
   .ma-share-label {
-    font-size: 0.72rem; letter-spacing: 0.06em;
-    color: var(--grey); font-weight: 600;
+    font-size: 0.76rem;
+    letter-spacing: 0.06em;
+    color: #5a5a5a;
+    font-weight: 600;
   }
   .ma-share a {
-    color: var(--grey); font-size: 1.15rem;
-    transition: color .2s; text-decoration: none;
+    color: #5a5a5a;
+    font-size: 1.2rem;
+    transition: color .2s;
+    text-decoration: none;
   }
-  .ma-share a:hover { color: var(--red); }
+  .ma-share a:hover { color: #D40035; }
 
+  /* Responsive */
   @media (max-width: 640px) {
-    .ma-hero img { max-height: 240px; }
-    .ma-header, .ma-body, .ma-footer { padding-left: 18px; padding-right: 18px; }
-    .ma-body > p:first-of-type::first-letter { font-size: 3.6em; }
+    .ma-hero { max-height: 280px; }
+    .ma-hero img { max-height: 280px; }
+    .ma-header { padding: 32px 18px 24px; }
+    .ma-body { padding: 28px 18px 24px; font-size: 1rem; }
+    .ma-footer { padding: 20px 18px 36px; }
   }
 </style>
 
@@ -202,10 +242,6 @@ layout: default
       <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | absolute_url }}"
          target="_blank" rel="noopener" aria-label="Condividi su Facebook" title="Condividi su Facebook">
         <i class="fa fa-facebook"></i>
-      </a>
-      <a href="#" onclick="navigator.clipboard.writeText('{{ page.url | absolute_url }}');return false;"
-         aria-label="Copia link" title="Copia link">
-        <i class="fa fa-link"></i>
       </a>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -7,183 +7,185 @@ description: "Science for the People Italia: scienza al servizio delle oppresse 
 ---
 
 <style>
-  /* ============================================================
-     HOME — MAGAZINE GRID
-     Scoped sotto .mag- per non collidere con W3.CSS o stili globali.
-     Usa le custom property già in style.css (--red, --dark, ecc.).
-     ============================================================ */
+  /* HOME — magazine grid (.mag- prefisso) */
+  .mag-home { background: #fff; color: #111; font-family: 'Dosis', sans-serif; }
 
-  .mag-home { background: var(--bg); color: var(--black); font-family: var(--font-sans); }
-
-  /* --- Featured hero (most recent post) + stacked list --- */
+  /* Featured + lista blog */
   .mag-feed {
     max-width: 1340px; margin: 0 auto;
-    padding: 48px 48px 56px;
-    display: grid; grid-template-columns: 1.6fr 1fr; gap: 56px; align-items: start;
+    padding: 48px 32px 56px;
+    display: grid; grid-template-columns: 1.6fr 1fr;
+    gap: 56px; align-items: start;
   }
   .mag-featured-image {
     width: 100%; height: 420px;
-    background: var(--dark);
-    overflow: hidden;
-    display: block;
+    background: #111; overflow: hidden;
   }
-  .mag-featured-image img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .mag-featured-image img {
+    width: 100%; height: 100%;
+    object-fit: cover; display: block;
+  }
   .mag-featured-meta {
     margin-top: 18px;
     display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
   }
   .mag-featured-badge {
-    background: var(--red); color: #fff;
-    font-family: var(--font-sans); font-weight: 700;
+    background: #D40035; color: #fff;
+    font-family: 'Dosis', sans-serif; font-weight: 700;
     font-size: 0.65rem; letter-spacing: 0.18em; text-transform: uppercase;
     padding: 5px 10px;
   }
   .mag-featured-cat {
-    font-family: var(--font-sans); font-weight: 700;
+    font-family: 'Dosis', sans-serif; font-weight: 700;
     font-size: 0.72rem; letter-spacing: 0.14em; text-transform: uppercase;
-    color: var(--red);
+    color: #D40035;
   }
   .mag-featured-date {
-    font-family: var(--font-sans); font-size: 0.78rem;
-    color: var(--grey); letter-spacing: 0.04em;
+    font-family: 'Dosis', sans-serif; font-size: 0.78rem;
+    color: #5a5a5a; letter-spacing: 0.04em;
   }
   .mag-featured-title {
-    font-family: var(--font-serif);
-    font-weight: 700; font-size: clamp(1.6rem, 3.2vw, 3rem);
-    line-height: 1.08; letter-spacing: -0.01em;
-    margin: 14px 0 12px; color: var(--black);
+    font-family: 'Lora', serif; font-weight: 700;
+    font-size: clamp(1.7rem, 3.4vw, 3rem); line-height: 1.08;
+    letter-spacing: -0.01em;
+    margin: 14px 0 12px; color: #000;
   }
-  .mag-featured-title a { color: inherit; text-decoration: none; transition: color .2s; }
-  .mag-featured-title a:hover { color: var(--red); }
+  .mag-featured-title a { color: inherit; text-decoration: none; }
+  .mag-featured-title a:hover { color: #D40035; }
   .mag-featured-dek {
-    font-family: var(--font-serif); font-style: italic;
-    font-size: 1.05rem; line-height: 1.55; color: var(--grey);
-    margin: 0; max-width: 640px;
+    font-family: 'Lora', serif; font-style: italic;
+    font-size: 1.05rem; line-height: 1.55;
+    color: #5a5a5a; margin: 0; max-width: 640px;
   }
 
-  /* --- Blog list (sidebar destra della home) --- */
+  /* Blog list a destra */
   .mag-bloglist-head {
     display: flex; justify-content: space-between; align-items: baseline;
-    padding-bottom: 10px; border-bottom: 2px solid var(--black);
+    padding-bottom: 10px; border-bottom: 2px solid #000;
     margin-bottom: 8px;
   }
   .mag-bloglist-title {
-    font-family: var(--font-sans); font-weight: 700;
+    font-family: 'Dosis', sans-serif; font-weight: 700;
     font-size: 0.85rem; letter-spacing: 0.14em; text-transform: uppercase;
-    color: var(--black);
+    color: #000;
   }
   .mag-bloglist-more {
-    font-family: var(--font-sans); font-weight: 700;
+    font-family: 'Dosis', sans-serif; font-weight: 700;
     font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase;
-    color: var(--red); text-decoration: none;
+    color: #D40035; text-decoration: none;
   }
   .mag-bloglist-item {
-    padding: 18px 0; border-bottom: 1px solid var(--grey-light);
+    padding: 18px 0; border-bottom: 1px solid #e8e8e8;
     display: grid; grid-template-columns: 58px 1fr; gap: 22px;
     align-items: start;
   }
   .mag-bloglist-num {
-    font-family: var(--font-sans); font-weight: 700;
-    font-size: 2.2rem; color: var(--red); line-height: 1;
+    font-family: 'Dosis', sans-serif; font-weight: 700;
+    font-size: 2.2rem; color: #D40035; line-height: 1;
     text-align: right;
   }
   .mag-bloglist-cat {
-    font-family: var(--font-sans); font-weight: 700;
+    font-family: 'Dosis', sans-serif; font-weight: 700;
     font-size: 0.68rem; letter-spacing: 0.14em; text-transform: uppercase;
-    color: var(--red);
+    color: #D40035;
   }
   .mag-bloglist-title-link {
-    font-family: var(--font-serif); font-weight: 700;
+    font-family: 'Lora', serif; font-weight: 700;
     font-size: 1.15rem; line-height: 1.25;
-    margin: 4px 0 0; display: block; color: var(--black); text-decoration: none;
+    margin: 4px 0 0; display: block; color: #000; text-decoration: none;
   }
-  .mag-bloglist-title-link:hover { color: var(--red); }
+  .mag-bloglist-title-link:hover { color: #D40035; }
   .mag-bloglist-date {
-    font-family: var(--font-sans); font-size: 0.7rem;
-    color: var(--grey); letter-spacing: 0.04em; margin-top: 8px;
+    font-family: 'Dosis', sans-serif; font-size: 0.7rem;
+    color: #5a5a5a; letter-spacing: 0.04em; margin-top: 8px;
   }
 
-  /* --- Chi siamo --- */
+  /* Chi siamo */
   .mag-chi-siamo {
-    padding: 56px 48px;
-    border-top: 1px solid var(--grey-light);
+    padding: 56px 32px;
+    border-top: 1px solid #e8e8e8;
   }
   .mag-chi-siamo-inner {
     max-width: 1340px; margin: 0 auto;
     display: grid; grid-template-columns: 1fr 2fr; gap: 56px; align-items: start;
   }
   .mag-chi-siamo h2 {
-    margin: 0;
-    font-family: var(--font-sans); font-weight: 700;
+    margin: 0 !important;
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700;
     font-size: clamp(2.4rem, 5vw, 3.8rem); line-height: 1;
-    letter-spacing: -0.01em; color: var(--red);
-    display: inline-block; padding-bottom: 8px;
-    border-bottom: 3px solid var(--red);
+    letter-spacing: -0.01em;
+    color: #D40035 !important;
+    display: inline-block;
+    padding-bottom: 8px;
+    border-bottom: 3px solid #D40035;
     position: sticky; top: 140px;
   }
   .mag-chi-siamo-body {
-    font-family: var(--font-serif); font-size: 1.05rem; line-height: 1.8;
-    color: var(--dark); max-width: 760px;
+    font-family: 'Lora', serif; font-size: 1.05rem; line-height: 1.8;
+    color: #222; max-width: 760px;
   }
   .mag-chi-siamo-body p {
     margin: 0 0 22px; text-align: justify; hyphens: auto; -webkit-hyphens: auto;
   }
   .mag-chi-siamo-claim {
     margin-top: 28px; padding: 24px 30px;
-    background: var(--black); color: #fff;
-    font-family: var(--font-sans); font-weight: 700;
+    background: #000; color: #fff;
+    font-family: 'Dosis', sans-serif; font-weight: 700;
     font-size: clamp(1.2rem, 2vw, 1.5rem); line-height: 1.3;
-    border-left: 6px solid var(--red);
+    border-left: 6px solid #D40035;
   }
   .mag-chi-siamo-cta { margin-top: 28px; display: flex; gap: 12px; flex-wrap: wrap; }
   .mag-btn {
-    background: var(--red); color: #fff !important;
-    padding: 13px 22px; font-family: var(--font-sans);
-    font-weight: 700; font-size: 0.78rem; letter-spacing: 0.08em;
+    background: #D40035; color: #fff !important;
+    padding: 13px 22px;
+    font-family: 'Dosis', sans-serif; font-weight: 700;
+    font-size: 0.78rem; letter-spacing: 0.08em;
     text-transform: uppercase; text-decoration: none !important;
-    transition: background .2s, transform .15s;
     display: inline-flex; align-items: center; gap: 8px;
+    transition: background .2s, transform .15s;
   }
-  .mag-btn:hover { background: var(--red-dark); transform: translateY(-1px); }
+  .mag-btn:hover { background: #a8002a; transform: translateY(-1px); }
   .mag-btn--outline {
-    background: transparent; color: var(--red) !important;
-    border: 2px solid var(--red); padding: 11px 20px;
+    background: transparent; color: #D40035 !important;
+    border: 2px solid #D40035; padding: 11px 20px;
   }
-  .mag-btn--outline:hover { background: var(--red); color: #fff !important; }
+  .mag-btn--outline:hover { background: #D40035; color: #fff !important; }
 
-  /* --- Partecipa + Scrivici --- */
-  .mag-engage { background: var(--bg-alt); padding: 56px 48px; }
+  /* Partecipa + Scrivici */
+  .mag-engage { background: #f7f5f5; padding: 56px 32px; }
   .mag-engage-inner {
     max-width: 1340px; margin: 0 auto;
     display: grid; grid-template-columns: 1fr 1fr; gap: 48px;
   }
   .mag-engage h2 {
-    margin: 0;
-    font-family: var(--font-sans); font-weight: 700;
+    margin: 0 !important;
+    font-family: 'Dosis', sans-serif !important;
+    font-weight: 700;
     font-size: clamp(1.8rem, 3.5vw, 2.8rem); line-height: 1;
-    color: var(--red); display: inline-block;
-    padding-bottom: 6px; border-bottom: 3px solid var(--red);
+    color: #D40035 !important; display: inline-block;
+    padding-bottom: 6px; border-bottom: 3px solid #D40035;
   }
   .mag-engage p {
-    font-family: var(--font-serif); font-size: 1.05rem;
-    line-height: 1.65; color: var(--dark); margin: 22px 0 0;
+    font-family: 'Lora', serif; font-size: 1.05rem;
+    line-height: 1.65; color: #222; margin: 22px 0 0;
   }
-  .mag-engage a.text-link { color: var(--red); font-weight: 700; text-decoration: none; }
+  .mag-engage a.text-link { color: #D40035; font-weight: 700; text-decoration: none; }
   .mag-engage a.text-link:hover { text-decoration: underline; }
   .mag-social-row { margin-top: 22px; display: flex; gap: 12px; flex-wrap: wrap; }
   .mag-social-icon {
     width: 52px; height: 52px; background: #fff;
-    border: 1.5px solid var(--grey-light);
+    border: 1.5px solid #e8e8e8;
     display: flex; align-items: center; justify-content: center;
-    color: var(--dark); text-decoration: none; font-size: 1.1rem;
+    color: #111; text-decoration: none; font-size: 1.1rem;
     transition: background .2s, color .2s, border-color .2s, transform .2s;
   }
   .mag-social-icon:hover {
-    background: var(--red-accent); color: #fff;
-    border-color: var(--red-accent); transform: translateY(-2px);
+    background: #FA4224; color: #fff;
+    border-color: #FA4224; transform: translateY(-2px);
   }
 
-  /* --- Responsive --- */
+  /* Responsive */
   @media (max-width: 992px) {
     .mag-feed { padding: 32px 20px 40px; grid-template-columns: 1fr; gap: 40px; }
     .mag-featured-image { height: 260px; }
@@ -193,16 +195,10 @@ description: "Science for the People Italia: scienza al servizio delle oppresse 
     .mag-engage { padding: 40px 20px; }
     .mag-engage-inner { grid-template-columns: 1fr; gap: 36px; }
   }
-  @media (max-width: 480px) {
-    .mag-featured-image { height: 200px; }
-    .mag-bloglist-item { grid-template-columns: 44px 1fr; gap: 16px; }
-    .mag-bloglist-num { font-size: 1.8rem; }
-  }
 </style>
 
 <div class="mag-home">
 
-  <!-- ====== FEATURED + BLOG LIST ====== -->
   {% assign posts = site.posts %}
   <section class="mag-feed">
     {% if posts.size > 0 %}
@@ -251,13 +247,12 @@ description: "Science for the People Italia: scienza al servizio delle oppresse 
         {% endfor %}
       </aside>
     {% else %}
-      <p style="grid-column: 1 / -1; font-family: var(--font-serif); font-style: italic; color: var(--grey); padding: 40px 0;">
+      <p style="grid-column: 1 / -1; font-family: 'Lora', serif; font-style: italic; color: #5a5a5a; padding: 40px 0;">
         Nessun articolo pubblicato.
       </p>
     {% endif %}
   </section>
 
-  <!-- ====== CHI SIAMO ====== -->
   <section id="Home" class="mag-chi-siamo">
     <div class="mag-chi-siamo-inner">
       <div><h2>CHI SIAMO?</h2></div>
@@ -273,18 +268,13 @@ description: "Science for the People Italia: scienza al servizio delle oppresse 
         </div>
 
         <div class="mag-chi-siamo-cta">
-          <a href="/manifesto" target="_blank" rel="noopener" class="mag-btn">
-            Il nostro manifesto <i class="fa fa-external-link" aria-hidden="true"></i>
-          </a>
-          <a href="https://magazine.scienceforthepeople.org/" target="_blank" rel="noopener" class="mag-btn mag-btn--outline">
-            SftP Magazine <i class="fa fa-external-link" aria-hidden="true"></i>
-          </a>
+          <a href="/manifesto" class="mag-btn">Il nostro manifesto <i class="fa fa-external-link" aria-hidden="true"></i></a>
+          <a href="https://magazine.scienceforthepeople.org/" target="_blank" rel="noopener" class="mag-btn mag-btn--outline">SftP Magazine <i class="fa fa-external-link" aria-hidden="true"></i></a>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- ====== PARTECIPA + SCRIVICI ====== -->
   <section class="mag-engage">
     <div class="mag-engage-inner">
       <div id="partecipa">


### PR DESCRIPTION
Redesign v4 — rifatto da zero. Corregge i problemi rimasti in v3.\n\n**File modificati (5):**\n- `_layouts/default.html` — rimosso il vecchio header mobile che si sovrapponeva\n- `_includes/navbar.html` — striscia nera + fascia bianca, selettori `sftp-*`, zero collisioni CSS\n- `_layouts/post.html` — titolo Dosis, body Lora 760px, footer share\n- `_layouts/manifesto.html` — hero scuro con watermark, body ampio\n- `index.html` — home magazine grid aggiornata

---
_Generated by [Claude Code](https://claude.ai/code/session_014bPnHiG9tc8WfdJkHtapt6)_