### PR TITLE
Splash d'apertura: il brand a schermo pieno si ripone nella topbar

### DIFF
--- a/_includes/splash.html
+++ b/_includes/splash.html
@@ -1,0 +1,173 @@
+<!-- ============================================================
+     SPLASH D'APERTURA — logo + scritta a schermo pieno che poi
+     scivola e si rimpicciolisce fino alla sua posizione nella topbar.
+     Mostrato una volta per sessione. Disattivato con prefers-reduced-motion.
+     Markup/stili rispecchiano .sftp-brand della navbar per un atterraggio
+     perfetto (FLIP: il brand grande al centro morfa su quello reale).
+     ============================================================ -->
+<div id="sftp-splash" aria-hidden="true">
+  <div class="sftp-splash-brand">
+    <span class="sftp-splash-logo">
+      <img src="/img/sftp_logo_fist.png" alt="Science for the People Italia">
+    </span>
+    <span class="sftp-splash-text">
+      <span class="sftp-splash-title">Science for the People <span class="sftp-splash-italia">Italia</span></span>
+      <span class="sftp-splash-sub">Scienza di Classe</span>
+    </span>
+  </div>
+</div>
+
+<style>
+  /* Overlay nascosto di default: niente trappola per chi ha JS disattivato. */
+  #sftp-splash {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 99990;
+    background: #ffffff;
+    align-items: center;
+    justify-content: center;
+    opacity: 1;
+    transition: opacity .5s ease;
+  }
+  #sftp-splash.sftp-show { display: flex; }
+  #sftp-splash.sftp-fade { opacity: 0; pointer-events: none; }
+
+  /* Blocca lo scroll mentre lo splash è attivo. */
+  .sftp-splash-lock,
+  .sftp-splash-lock body { overflow: hidden !important; }
+
+  /* Brand dello splash: ancorato in alto a sinistra per misure pulite,
+     posizionato/scalato via JS. Stili identici a .sftp-brand della navbar. */
+  .sftp-splash-brand {
+    position: absolute;
+    top: 0; left: 0;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    opacity: 0;
+    transform-origin: top left;
+    will-change: transform, opacity;
+  }
+  .sftp-splash-logo {
+    width: 112px; height: 104px;
+    flex-shrink: 0;
+  }
+  .sftp-splash-logo img {
+    width: 100%; height: 100%;
+    object-fit: contain;
+    display: block;
+  }
+  .sftp-splash-text {
+    display: flex;
+    flex-direction: column;
+    line-height: 1;
+  }
+  .sftp-splash-title {
+    font-family: 'Dosis', sans-serif;
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: #000;
+    line-height: 1.05;
+    letter-spacing: 0.005em;
+    white-space: nowrap;
+  }
+  .sftp-splash-italia { color: #D40035; }
+  .sftp-splash-sub {
+    font-family: 'Dosis', sans-serif;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #5a5a5a;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    margin-top: 6px;
+  }
+  @media (max-width: 900px) {
+    .sftp-splash-logo { width: 64px; height: 60px; }
+    .sftp-splash-title { font-size: 1.1rem; }
+    .sftp-splash-sub { font-size: 0.6rem; letter-spacing: 0.18em; margin-top: 3px; }
+  }
+</style>
+
+<script>
+  /* Decisione immediata (prima del primo paint): mostrare o no lo splash.
+     Sta subito dopo l'elemento, così aggiungere .sftp-show non causa flash. */
+  (function () {
+    var el = document.getElementById('sftp-splash');
+    if (!el) return;
+    var reduce = window.matchMedia &&
+                 window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var seen = false;
+    try { seen = sessionStorage.getItem('sftp_splash_seen') === '1'; } catch (e) {}
+    if (reduce || seen) return; // resta display:none → sito normale
+    try { sessionStorage.setItem('sftp_splash_seen', '1'); } catch (e) {}
+    el.classList.add('sftp-show');
+    document.documentElement.classList.add('sftp-splash-lock');
+  })();
+</script>
+
+<script>
+  /* Animazione: comparsa al centro grande → scivola nella topbar. */
+  (function () {
+    var el = document.getElementById('sftp-splash');
+    if (!el) return;
+
+    function run() {
+      if (!el.classList.contains('sftp-show')) return;
+
+      var brand = el.querySelector('.sftp-splash-brand');
+      var real  = document.querySelector('#sftp-topbar .sftp-brand');
+
+      function finish() {
+        el.classList.add('sftp-fade');
+        document.documentElement.classList.remove('sftp-splash-lock');
+        setTimeout(function () { el.style.display = 'none'; }, 550);
+      }
+
+      if (!brand || !real) { finish(); return; }
+
+      var vw = window.innerWidth, vh = window.innerHeight;
+
+      // Rettangolo naturale del brand dello splash (senza transform).
+      brand.style.transition = 'none';
+      brand.style.transform = 'none';
+      var R1 = brand.getBoundingClientRect();
+      // Rettangolo reale del brand nella topbar (destinazione).
+      var R2 = real.getBoundingClientRect();
+
+      // Fattore d'ingrandimento centrale (cap a 4.5, mai più piccolo del reale).
+      var k = Math.min(4.5, Math.max(1,
+        Math.min((vw * 0.9) / R1.width, (vh * 0.55) / R1.height)));
+
+      // Stato "grande centrato".
+      var cx = (vw - k * R1.width) / 2;
+      var cy = (vh - k * R1.height) / 2;
+      var bigTX = cx - R1.left, bigTY = cy - R1.top;
+
+      // Stato finale: sovrapposto esattamente al brand reale.
+      var s = R2.width / R1.width;
+      var finTX = R2.left - R1.left, finTY = R2.top - R1.top;
+
+      // Entrata: parte poco più in basso e trasparente, sale e appare.
+      brand.style.transform = 'translate(' + bigTX + 'px,' + (bigTY + 16) + 'px) scale(' + k + ')';
+      brand.style.opacity = '0';
+      void brand.offsetWidth; // forza reflow
+      brand.style.transition = 'transform .6s cubic-bezier(.22,1,.36,1), opacity .6s ease';
+      brand.style.transform = 'translate(' + bigTX + 'px,' + bigTY + 'px) scale(' + k + ')';
+      brand.style.opacity = '1';
+
+      // Pausa, poi scivola fino al suo posto nella topbar.
+      setTimeout(function () {
+        brand.style.transition = 'transform .9s cubic-bezier(.62,.04,.3,1)';
+        brand.style.transform = 'translate(' + finTX + 'px,' + finTY + 'px) scale(' + s + ')';
+        setTimeout(finish, 820); // a movimento concluso, dissolve l'overlay
+      }, 950);
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', run);
+    } else {
+      run();
+    }
+  })();
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,6 +78,9 @@
 
 <body>
 
+  <!-- Splash d'apertura: brand a schermo pieno che si ripone nella topbar -->
+  {% include splash.html %}
+
   <!-- Sidebar (resta per accessibilità mobile via hamburger del topbar) -->
   {% include sidebar.html %}
 


### PR DESCRIPTION
## Cosa fa

Aggiunge una schermata d'apertura (splash) all'arrivo sul sito:

1. Logo + scritta **Science for the People Italia / Scienza di Classe** compaiono grandi al centro dello schermo.
2. Poi scivolano e si rimpiccioliscono fino ad atterrare **esattamente nella loro posizione reale** nella barra in alto (effetto morph/FLIP: lo splash usa gli stessi identici stili del brand della navbar, così la sovrapposizione finale è perfetta e l'overlay sfuma via senza scatti).

Nuovo include `_includes/splash.html` collegato al layout `default.html`.

## Dettagli
- **Una volta per sessione** (`sessionStorage`): non si ripete a ogni cambio pagina.
- **Accessibilità**: saltato con `prefers-reduced-motion`.
- **Robustezza**: overlay nascosto di default e mostrato solo via JS → chi ha JS disattivato non resta mai bloccato; scroll bloccato solo durante l'animazione (~2,5 s).

## Verifica
- Build Jekyll OK.
- Splash renderizzato in home, blog, manifesto e articoli.
- Asset logo `/img/sftp_logo_fist.png` presente.

https://claude.ai/code/session_01BTxoDu1DJvnqoECZ2rFdMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTxoDu1DJvnqoECZ2rFdMV)_