### PR TITLE
Splash: compensa la scrollbar per evitare lo scatto a sinistra

### DIFF
--- a/_includes/splash.html
+++ b/_includes/splash.html
@@ -121,7 +121,9 @@
     if (reduce || seen) return; // resta display:none → sito normale
     try { sessionStorage.setItem('sftp_splash_seen', '1'); } catch (e) {}
     el.classList.add('sftp-show');
-    document.documentElement.classList.add('sftp-splash-lock', 'sftp-booting');
+    // Solo "booting" (nasconde i contenuti): il blocco scroll viene applicato
+    // più avanti, con compensazione della scrollbar per evitare spostamenti.
+    document.documentElement.classList.add('sftp-booting');
   })();
 </script>
 
@@ -142,7 +144,9 @@
       reveal();                        // in parallelo: appare il sito
       setTimeout(function () {
         el.style.display = 'none';
+        // Sblocca lo scroll e rimuove la compensazione insieme: nessuno spostamento.
         document.documentElement.classList.remove('sftp-splash-lock');
+        document.documentElement.style.paddingRight = '';
       }, 720);
     }
 
@@ -186,6 +190,11 @@
 
     function run() {
       if (!el.classList.contains('sftp-show')) return;
+      // Blocca lo scroll compensando la larghezza della scrollbar: così navbar
+      // e contenuti non si spostano a sinistra quando lo scroll viene sbloccato.
+      var sbw = window.innerWidth - document.documentElement.clientWidth;
+      if (sbw > 0) document.documentElement.style.paddingRight = sbw + 'px';
+      document.documentElement.classList.add('sftp-splash-lock');
       var started = false;
       function go() { if (started) return; started = true; animate(); }
       // Aspetta che i font siano pronti: così le misure (e l'atterraggio) sono esatte.


### PR DESCRIPTION
## Problema

Subito dopo l'atterraggio dello splash, navbar e griglia del blog si spostavano a sinistra.

**Causa:** durante lo splash blocco lo scroll con `overflow: hidden`, che fa sparire la scrollbar verticale allargando la pagina di ~15px. Allo sblocco la scrollbar ricompare, l'area si restringe e gli elementi allineati a destra/centrati (navbar, blog) scattano a sinistra.

## Fix

Riservo lo spazio della scrollbar (`padding-right` pari alla sua larghezza) sull'elemento `html` mentre lo scroll è bloccato, e lo rimuovo **insieme** allo sblocco. Così la larghezza del contenuto resta costante prima, durante e dopo lo splash → nessuno scatto.

- La larghezza della scrollbar viene misurata nello stato naturale (a DOMContentLoaded, prima del lock).
- Se non c'è scrollbar (pagina corta o scrollbar overlay), `padding-right = 0` → nessun effetto.

## Verifica
- Build Jekyll OK.

https://claude.ai/code/session_01BTxoDu1DJvnqoECZ2rFdMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTxoDu1DJvnqoECZ2rFdMV)_