### PR TITLE
Splash: niente ricomparsa aprendo articoli in nuova scheda

### DIFF
--- a/_includes/splash.html
+++ b/_includes/splash.html
@@ -110,16 +110,26 @@
 
 <script>
   /* Decisione immediata (prima del primo paint): mostrare o no lo splash.
-     Sta subito dopo l'elemento, così aggiungere le classi non causa flash. */
+     Usa localStorage (condivisa tra tutte le schede) con una finestra di
+     inattività: così lo splash compare a una nuova visita ma NON durante la
+     navigazione, nemmeno aprendo gli articoli in una nuova scheda. */
   (function () {
     var el = document.getElementById('sftp-splash');
     if (!el) return;
     var reduce = window.matchMedia &&
                  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    var seen = false;
-    try { seen = sessionStorage.getItem('sftp_splash_seen') === '1'; } catch (e) {}
-    if (reduce || seen) return; // resta display:none → sito normale
-    try { sessionStorage.setItem('sftp_splash_seen', '1'); } catch (e) {}
+    if (reduce) return; // sito normale
+
+    var KEY = 'sftp_splash_ts';
+    var WINDOW = 30 * 60 * 1000; // 30 minuti di inattività = nuova visita
+    var now = Date.now();
+    var last = 0;
+    try { last = parseInt(localStorage.getItem(KEY), 10) || 0; } catch (e) {}
+    var recente = (now - last) < WINDOW;
+    // Aggiorna sempre il "timbro" di attività (finestra scorrevole).
+    try { localStorage.setItem(KEY, String(now)); } catch (e) {}
+    if (recente) return; // già visitato di recente → niente splash
+
     el.classList.add('sftp-show');
     // Solo "booting" (nasconde i contenuti): il blocco scroll viene applicato
     // più avanti, con compensazione della scrollbar per evitare spostamenti.


### PR DESCRIPTION
## Problema

Entrando nel primo articolo del blog in evidenza, "certe volte" ricompariva lo splash.

**Causa:** lo stato "già visto" era in `sessionStorage`, che **non viene ereditata** quando un link viene aperto in una **nuova scheda** (Ctrl/Cmd+click o "apri in nuova scheda"). In quei casi il flag mancava e lo splash ripartiva — da qui il "non sempre". (Verificato: gli articoli non usano `target="_blank"` e il dominio è unico, quindi non era un problema di origine.)

## Fix

Passo da `sessionStorage` a `localStorage` (condivisa tra **tutte le schede** dello stesso sito) con una **finestra di inattività di 30 minuti**:

- lo splash compare a una nuova visita;
- non ricompare durante la navigazione, **nemmeno aprendo articoli in nuove schede**;
- il "timbro" di attività viene aggiornato a ogni pagina (finestra scorrevole), quindi riappare solo dopo ~30 min di inattività.

Resta il rispetto di `prefers-reduced-motion` e i fallback se lo storage non è disponibile.

## Verifica
- Build Jekyll OK; logica presente in home, blog e articoli.

https://claude.ai/code/session_01BTxoDu1DJvnqoECZ2rFdMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTxoDu1DJvnqoECZ2rFdMV)_