### PR TITLE
Aggiungi workflow GitHub Actions per il deploy di Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Consenti un solo deploy concorrente, saltando quelli in coda tra un run e l'altro.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Aggiunge `.github/workflows/pages.yml`: il workflow standard Jekyll → GitHub Pages (build con Ruby/Jekyll 4.3.4 + `actions/deploy-pages`).
- Con la sorgente di Pages impostata su **"GitHub Actions"** (come ora), il repo **deve** avere un proprio workflow per deployare: senza, nessun push produce un deploy (motivo per cui i push recenti non generavano più run).
- Fornisce un percorso di deploy pulito, versionato e indipendente dal run "dynamic" `28601180546` rimasto bloccato in coda.

## Contesto
- Ultimo deploy riuscito: 29 maggio (commit 1163e94). Da allora il sito non riceve aggiornamenti a causa di un problema sul deployment di Pages.
- Questo è un tentativo di ripristino attraverso un workflow controllato, da eseguire dopo l'"Unpublish site" già fatto in Settings > Pages.

https://claude.ai/code/session_01PFND8ywxHxZt6FyJeSnbsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFND8ywxHxZt6FyJeSnbsr)_