### PR TITLE
Aggiungi piattaforma x86_64-linux al Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,11 +14,15 @@ GEM
     eventmachine (1.2.7)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x64-mingw-ucrt)
+    ffi (1.17.2-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     google-protobuf (4.33.0-arm64-darwin)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.33.0-x64-mingw-ucrt)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.0-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -75,6 +79,8 @@ GEM
       google-protobuf (~> 4.28)
     sass-embedded (1.81.0-x64-mingw-ucrt)
       google-protobuf (~> 4.28)
+    sass-embedded (1.81.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.28)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     tzinfo (2.0.6)
@@ -89,6 +95,7 @@ PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   base64


### PR DESCRIPTION
## Summary
- Il workflow di deploy (PR #52) falliva allo step "Setup Ruby" perché `bundle install` non trovava la piattaforma del runner:
  > Your bundle only supports platforms ["arm64-darwin-23", "arm64-darwin-24", "x64-mingw-ucrt"] but your local platform is x86_64-linux
- Aggiunge `x86_64-linux` a `Gemfile.lock` con `bundle lock --add-platform x86_64-linux`. Build Jekyll verificata localmente (OK).

Con questo fix, il workflow "Deploy Jekyll site to Pages" dovrebbe completare build + deploy.

https://claude.ai/code/session_01PFND8ywxHxZt6FyJeSnbsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFND8ywxHxZt6FyJeSnbsr)_